### PR TITLE
Updated SwiftUIIntrospect to v1.0.0

### DIFF
--- a/ExyteChat.podspec
+++ b/ExyteChat.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
      'Sources/**/*.swift'
   ]
 
-  s.dependency 'Introspect'
+  s.dependency 'SwiftUIIntrospect'
   s.dependency 'ExyteMediaPicker'
   s.dependency 'FloatingButton'
   s.dependency 'ActivityIndicatorView'

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/siteline/SwiftUI-Introspect.git",
-            from: "0.1.4"
+            url: "https://github.com/siteline/swiftui-introspect",
+            from: "1.0.0"
         ),
         .package(
             url: "https://github.com/exyte/MediaPicker.git",
@@ -35,7 +35,7 @@ let package = Package(
         .target(
             name: "ExyteChat",
             dependencies: [
-                .product(name: "Introspect", package: "SwiftUI-Introspect"),
+                .product(name: "SwiftUIIntrospect", package: "swiftui-introspect"),
                 .product(name: "ExyteMediaPicker", package: "MediaPicker"),
                 .product(name: "FloatingButton", package: "FloatingButton"),
                 .product(name: "ActivityIndicatorView", package: "ActivityIndicatorView")

--- a/Sources/ExyteChat/ChatView/ChatView.swift
+++ b/Sources/ExyteChat/ChatView/ChatView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import FloatingButton
-import Introspect
+import SwiftUIIntrospect
 import ExyteMediaPicker
 
 public typealias MediaPickerParameters = SelectionParamsHolder
@@ -210,11 +210,11 @@ public struct ChatView<MessageContent: View, InputViewContent: View>: View {
                         ScrollView {
                             messageMenu(row)
                         }
-                        .introspectScrollView { scrollView in
-                            DispatchQueue.main.async {
-                                self.menuScrollView = scrollView
-                            }
-                        }
+						.introspect(.scrollView, on: .iOS(.v16, .v17), customize: { scrollView in
+							DispatchQueue.main.async {
+								self.menuScrollView = scrollView
+							}
+						})
                         .opacity(readyToShowScrollView ? 1 : 0)
                     }
                     if !needsScrollView || !readyToShowScrollView {


### PR DESCRIPTION
The previous version of SwiftUIIntrospect was deprecated and displayed warnings. The also fixes a dependency conflict I was facing with using another library that depended on a newer version of SwiftUIIntrospect.