### PR TITLE
Specify inlineOnlyPreservingWhitespace for Markdown strings. (#52)

### DIFF
--- a/Sources/ExyteChat/ChatView/MessageView/MessageTextView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageTextView.swift
@@ -21,7 +21,15 @@ struct MessageTextView: View {
     @ViewBuilder
     private func textView(_ text: String) -> some View {
         if messageUseMarkdown,
-           let attributed = try? AttributedString(markdown: text) {
+           let attributed = try? AttributedString(
+               markdown: text,
+               options: AttributedString.MarkdownParsingOptions(
+                   allowsExtendedAttributes: false,
+                   interpretedSyntax: .inlineOnlyPreservingWhitespace,
+                   failurePolicy: .returnPartiallyParsedIfPossible,
+                   languageCode: nil
+               )
+           ) {
             Text(attributed)
         } else {
             Text(text)

--- a/Sources/ExyteChat/Extensions/String+Size.swift
+++ b/Sources/ExyteChat/Extensions/String+Size.swift
@@ -17,7 +17,13 @@ extension String {
     }
 
     func toAttrString(font: UIFont, messageUseMarkdown: Bool) -> NSAttributedString {
-        var str = messageUseMarkdown ? (try? AttributedString(markdown: self)) ?? AttributedString(self) : AttributedString(self)
+        let markdownOptions = AttributedString.MarkdownParsingOptions(
+            allowsExtendedAttributes: false,
+            interpretedSyntax: .inlineOnlyPreservingWhitespace,
+            failurePolicy: .returnPartiallyParsedIfPossible,
+            languageCode: nil
+        )
+        var str = messageUseMarkdown ? (try? AttributedString(markdown: self, options: markdownOptions)) ?? AttributedString(self) : AttributedString(self)
         str.setAttributes(AttributeContainer([.font: font]))
         return NSAttributedString(str)
     }


### PR DESCRIPTION
This makes newlines work.

Note that this change doesn't stop the library from using `AttributedString`, so I suspect the concern you uncovered in #52 doesn't apply.

I've tested this in place in my own app; timestamps do not overlap text, and everything generally looks good. I would appreciate it if you would test as you normally do for changes — I might have missed something!