### PR TITLE
Remove reply on hold message

### DIFF
--- a/Sources/ExyteChat/ChatView/UIList.swift
+++ b/Sources/ExyteChat/ChatView/UIList.swift
@@ -418,7 +418,8 @@ struct UIList<MessageContent: View>: UIViewRepresentable {
                     .onTapGesture { }
                     .applyIf(showMessageMenuOnLongPress) {
                         $0.onLongPressGesture {
-                            self.viewModel.messageMenuRow = row
+                            // As its not need now: "Remove reply on hold message"
+    //                        self.viewModel.messageMenuRow = row
                         }
                     }
             }


### PR DESCRIPTION
When we hold the text on messages it shows reply we need to remove the function (commenting it for later use would be better)