### PR TITLE
Fix: Date header coming inverted

### DIFF
--- a/Sources/ExyteChat/ChatView/UIList.swift
+++ b/Sources/ExyteChat/ChatView/UIList.swift
@@ -489,7 +489,6 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
                 } else {
                     Text(sections[section].formattedDate)
                         .font(.system(size: 11))
-                        .rotationEffect(Angle(degrees: (type == .conversation ? 180 : 0)))
                         .padding(10)
                         .padding(.bottom, 8)
                         .foregroundColor(.gray)


### PR DESCRIPTION
Fix: Bug [Issue-79](https://github.com/exyte/Chat/issues/79)

Cause: We are inverting the header view and also the date view inside it leading to date headers being inverted.