### PR TITLE
Fix: #94,#97,#99

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Chat",
+    defaultLocalization: "en",
     platforms: [
         .iOS(.v16)
     ],

--- a/Sources/ExyteChat/ChatView/Attachments/AttachmentCell.swift
+++ b/Sources/ExyteChat/ChatView/Attachments/AttachmentCell.swift
@@ -26,7 +26,7 @@ struct AttachmentCell: View {
             } else {
                 content
                     .overlay {
-                        Text("Unknown")
+                        Text("Unknown", bundle: .module)
                     }
             }
         }

--- a/Sources/ExyteChat/ChatView/Attachments/AttachmentsEditor.swift
+++ b/Sources/ExyteChat/ChatView/Attachments/AttachmentsEditor.swift
@@ -134,7 +134,7 @@ struct AttachmentsEditor<InputViewContent: View>: View {
                     seleсtedMedias = []
                     inputViewModel.showPicker = false
                 } label: {
-                    Text("Cancel")
+                    Text("Cancel", bundle: .module)
                         .foregroundColor(.white.opacity(0.7))
                 }
 
@@ -142,7 +142,7 @@ struct AttachmentsEditor<InputViewContent: View>: View {
             }
 
             HStack {
-                Text("Recents")
+                Text("Recents", bundle: .module)
                 Image(systemName: "chevron.down")
                     .rotationEffect(Angle(radians: showingAlbums ? .pi : 0))
             }

--- a/Sources/ExyteChat/ChatView/Attachments/AttachmentsPage.swift
+++ b/Sources/ExyteChat/ChatView/Attachments/AttachmentsPage.swift
@@ -31,7 +31,7 @@ struct AttachmentsPage: View {
                 .frame(minWidth: 100, minHeight: 100)
                 .frame(maxHeight: 200)
                 .overlay {
-                    Text("Unknown")
+                    Text("Unknown", bundle: .module)
                 }
         }
     }

--- a/Sources/ExyteChat/ChatView/ChatView.swift
+++ b/Sources/ExyteChat/ChatView/ChatView.swift
@@ -223,7 +223,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
             HStack {
                 Spacer()
                 Image("waiting", bundle: .current)
-                Text("Waiting for network")
+                Text("Waiting for network", bundle: .module)
                 Spacer()
             }
             .padding(.top, 6)

--- a/Sources/ExyteChat/ChatView/ChatViewModel.swift
+++ b/Sources/ExyteChat/ChatView/ChatViewModel.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Combine
+import UIKit
 
 final class ChatViewModel: ObservableObject {
 
@@ -43,6 +44,8 @@ final class ChatViewModel: ObservableObject {
     @MainActor
     func messageMenuActionInternal(message: Message, action: DefaultMessageMenuAction) {
         switch action {
+        case .copy:
+            UIPasteboard.general.string = message.text
         case .reply:
             inputViewModel?.attachments.replyMessage = message.toReplyMessage()
             globalFocusState?.focus = .uuid(inputFieldId)

--- a/Sources/ExyteChat/ChatView/InputView/InputView.swift
+++ b/Sources/ExyteChat/ChatView/InputView/InputView.swift
@@ -280,7 +280,7 @@ struct InputView: View {
                         .foregroundColor(theme.colors.myMessage)
                         .frame(width: 2)
                     VStack(alignment: .leading) {
-                        Text("Reply to \(message.user.name)")
+                        Text(String(localized: "Reply to \(message.user.name)", bundle: .module))
                             .font(.caption2)
                             .foregroundColor(theme.colors.buttonBackground)
                         if !message.text.isEmpty {
@@ -428,7 +428,7 @@ struct InputView: View {
             } label: {
                 HStack {
                     theme.images.recordAudio.cancelRecord
-                    Text("Cancel")
+                    Text("Cancel", bundle: .module)
                         .font(.footnote)
                         .foregroundColor(theme.colors.textLightContext)
                 }
@@ -440,7 +440,7 @@ struct InputView: View {
     var recordingInProgress: some View {
         HStack {
             Spacer()
-            Text("Recording...")
+            Text("Recording...", bundle: .module)
                 .font(.footnote)
                 .foregroundColor(theme.colors.textLightContext)
             Spacer()

--- a/Sources/ExyteChat/ChatView/InputView/InputView.swift
+++ b/Sources/ExyteChat/ChatView/InputView/InputView.swift
@@ -503,7 +503,9 @@ struct InputView: View {
                 }
                 .frame(width: 20)
 
-                RecordWaveformPlaying(samples: samples, progress: recordingPlayer.progress, color: theme.colors.textLightContext, addExtraDots: true)
+                RecordWaveformPlaying(samples: samples, progress: recordingPlayer.progress, color: theme.colors.textLightContext, addExtraDots: true) { progress in
+                    recordingPlayer.seek(with: viewModel.attachments.recording!, to: progress)
+                }
             }
             .padding(.horizontal, 8)
         }

--- a/Sources/ExyteChat/ChatView/InputView/TextInputView.swift
+++ b/Sources/ExyteChat/ChatView/InputView/TextInputView.swift
@@ -19,7 +19,7 @@ struct TextInputView: View {
         TextField("", text: $text, axis: .vertical)
             .customFocus($globalFocusState.focus, equals: .uuid(inputFieldId))
             .placeholder(when: text.isEmpty) {
-                Text(style.placeholder)
+                Text(LocalizedStringKey(style.placeholder), bundle: .module)
                     .foregroundColor(theme.colors.buttonBackground)
             }
             .foregroundColor(style == .message ? theme.colors.textLightContext : theme.colors.textDarkContext)

--- a/Sources/ExyteChat/ChatView/MessageView/MessageMenu.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageMenu.swift
@@ -16,11 +16,14 @@ public protocol MessageMenuAction: Equatable, CaseIterable {
 
 public enum DefaultMessageMenuAction: MessageMenuAction {
 
+    case copy
     case reply
     case edit(saveClosure: (String)->Void)
 
     public func title() -> String {
         switch self {
+        case .copy:
+            "Copy"
         case .reply:
             "Reply"
         case .edit:
@@ -30,6 +33,8 @@ public enum DefaultMessageMenuAction: MessageMenuAction {
 
     public func icon() -> Image {
         switch self {
+        case .copy:
+            Image(systemName: "doc.on.doc")
         case .reply:
             Image(.reply)
         case .edit:
@@ -38,17 +43,18 @@ public enum DefaultMessageMenuAction: MessageMenuAction {
     }
 
     public static func == (lhs: DefaultMessageMenuAction, rhs: DefaultMessageMenuAction) -> Bool {
-        if case .reply = lhs, case .reply = rhs {
+        switch (lhs, rhs) {
+        case (.copy, .copy),
+             (.reply, .reply),
+             (.edit(_), .edit(_)):
             return true
+        default:
+            return false
         }
-        if case .edit(_) = lhs, case .edit(_) = rhs {
-            return true
-        }
-        return false
     }
 
     public static var allCases: [DefaultMessageMenuAction] = [
-        .reply, .edit(saveClosure: {_ in})
+        .copy, .reply, .edit(saveClosure: {_ in})
     ]
 }
 

--- a/Sources/ExyteChat/ChatView/MessageView/MessageMenu.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageMenu.swift
@@ -101,7 +101,7 @@ struct MessageMenu<MainButton: View, ActionEnum: MessageMenuAction>: View {
                     .opacity(0.5)
                     .cornerRadius(12)
                 HStack {
-                    Text(title)
+                    Text(LocalizedStringKey(title), bundle: .module)
                         .foregroundColor(theme.colors.textLightContext)
                     Spacer()
                     icon

--- a/Sources/ExyteChat/ChatView/Recording/RecordWaveform.swift
+++ b/Sources/ExyteChat/ChatView/Recording/RecordWaveform.swift
@@ -12,9 +12,11 @@ struct RecordWaveformWithButtons: View {
     @Environment(\.chatTheme) private var theme
 
     @StateObject var recordPlayer = RecordingPlayer()
-    //160 is screen left-padding/right-padding and playButton's width.
-    //To ensure that the view does not exceed the screen, need to subtract
-    static let viewPadding:CGFloat = 160
+
+    // 160 is screen left-padding/right-padding and playButton's width.
+    // ensure that the view does not exceed the screen, need to subtract
+    // TODO: do not hardcode this value
+    static let viewPadding: CGFloat = 160
 
     var recording: Recording
 
@@ -56,7 +58,6 @@ struct RecordWaveformWithButtons: View {
 }
 
 struct RecordWaveformPlaying: View {
-    
     var samples: [CGFloat] // 0...1
     var progress: CGFloat
     var color: Color
@@ -75,7 +76,6 @@ struct RecordWaveformPlaying: View {
     }
 
     var body: some View {
-        
         GeometryReader { g in
             ZStack {
                 let adjusted = addExtraDots ? adjustedSamples(g.size.width) : adjustedSamples
@@ -100,14 +100,14 @@ struct RecordWaveformPlaying: View {
     }
 
     func adjustedSamples(_ maxWidth: CGFloat) -> [CGFloat] {
-        
         let maxSamples = Int((maxWidth - RecordWaveformWithButtons.viewPadding) / (RecordWaveform.width + RecordWaveform.spacing))
         let temp = samples
         
         if temp.count <= maxSamples {
             return temp
         }
-        //Use ceil to ensure that the adjusted.count will not be greater than maxSamples
+
+        // use ceil to ensure that the adjusted.count will not be greater than maxSamples
         let ratio = Int(ceil( Double(temp.count) / Double(maxSamples) ))
         let adjusted = stride(from: 0, to: temp.count, by: ratio).map {
             temp[$0]

--- a/Sources/ExyteChat/ChatView/Recording/RecordWaveform.swift
+++ b/Sources/ExyteChat/ChatView/Recording/RecordWaveform.swift
@@ -56,6 +56,9 @@ struct RecordWaveformWithButtons: View {
                     .foregroundColor(colorWaveform)
             }
         }
+        .onDisappear {
+            recordPlayer.pause()
+        }
     }
 }
 

--- a/Sources/ExyteChat/ChatView/Recording/RecordWaveform.swift
+++ b/Sources/ExyteChat/ChatView/Recording/RecordWaveform.swift
@@ -12,6 +12,9 @@ struct RecordWaveformWithButtons: View {
     @Environment(\.chatTheme) private var theme
 
     @StateObject var recordPlayer = RecordingPlayer()
+    //160 is screen left-padding/right-padding and playButton's width.
+    //To ensure that the view does not exceed the screen, need to subtract
+    static let viewPadding:CGFloat = 160
 
     var recording: Recording
 
@@ -53,20 +56,29 @@ struct RecordWaveformWithButtons: View {
 }
 
 struct RecordWaveformPlaying: View {
-
+    
     var samples: [CGFloat] // 0...1
     var progress: CGFloat
     var color: Color
     var addExtraDots: Bool
-
-    var maxLength: CGFloat {
-        max((RecordWaveform.spacing + RecordWaveform.width) * CGFloat(samples.count) - RecordWaveform.spacing, 0)
+    var maxLength: CGFloat = 0.0
+    
+    private var adjustedSamples: [CGFloat] = []
+    
+    init(samples: [CGFloat], progress: CGFloat, color: Color, addExtraDots: Bool) {
+        self.samples = samples
+        self.progress = progress
+        self.color = color
+        self.addExtraDots = addExtraDots
+        self.adjustedSamples = adjustedSamples(UIScreen.main.bounds.width)
+        self.maxLength = max((RecordWaveform.spacing + RecordWaveform.width) * CGFloat(self.adjustedSamples.count) - RecordWaveform.spacing, 0)
     }
 
     var body: some View {
+        
         GeometryReader { g in
             ZStack {
-                let adjusted = adjustedSamples(g.size.width)
+                let adjusted = addExtraDots ? adjustedSamples(g.size.width) : adjustedSamples
                 RecordWaveform(samples: adjusted, addExtraDots: addExtraDots)
                     .foregroundColor(color.opacity(0.4))
                 RecordWaveform(samples: adjusted, addExtraDots: addExtraDots)
@@ -77,6 +89,7 @@ struct RecordWaveformPlaying: View {
                     }
             }
             .frame(height: RecordWaveform.maxSampleHeight)
+            
         }
         .frame(height: RecordWaveform.maxSampleHeight)
         .applyIf(!addExtraDots) {
@@ -86,27 +99,22 @@ struct RecordWaveformPlaying: View {
         .fixedSize(horizontal: !addExtraDots, vertical: true)
     }
 
-    func adjustedSamples(_ width: CGFloat) -> [CGFloat] {
-        let maxWidth = addExtraDots ? width : UIScreen.main.bounds.width
-        let maxSamples = Int(maxWidth / (RecordWaveform.width + RecordWaveform.spacing))
-
-        var adjusted = samples
-        var temp = [CGFloat]()
-        while adjusted.count > maxSamples {
-            var i = 0
-            while i < adjusted.count {
-                if i == adjusted.count - 1 {
-                    temp.append(adjusted[i])
-                    break
-                }
-
-                temp.append((adjusted[i] + adjusted[i+1])/2)
-                i+=2
-            }
-            adjusted = temp
-            temp = []
+    func adjustedSamples(_ maxWidth: CGFloat) -> [CGFloat] {
+        
+        let maxSamples = Int((maxWidth - RecordWaveformWithButtons.viewPadding) / (RecordWaveform.width + RecordWaveform.spacing))
+        let temp = samples
+        
+        if temp.count <= maxSamples {
+            return temp
         }
+        //Use ceil to ensure that the adjusted.count will not be greater than maxSamples
+        let ratio = Int(ceil( Double(temp.count) / Double(maxSamples) ))
+        let adjusted = stride(from: 0, to: temp.count, by: ratio).map {
+            temp[$0]
+        }
+        
         return adjusted
+        
     }
 }
 
@@ -126,9 +134,9 @@ struct RecordWaveform: View {
                     Capsule()
                         .frame(width: RecordWaveform.width, height: RecordWaveform.maxSampleHeight * CGFloat(s))
                 }
-
-                if addExtraDots {
-                    ForEach(samples.count..<Int(g.size.width / (RecordWaveform.width + RecordWaveform.spacing)), id: \.self) { _ in
+                let maxSampleCounts = Int((g.size.width) / (RecordWaveform.width + RecordWaveform.spacing))
+                if addExtraDots && samples.count < maxSampleCounts {
+                    ForEach(samples.count..<maxSampleCounts, id: \.self) { _ in
                         Capsule()
                             .viewSize(RecordWaveform.width)
                     }

--- a/Sources/ExyteChat/ChatView/Recording/Recorder.swift
+++ b/Sources/ExyteChat/ChatView/Recording/Recorder.swift
@@ -42,15 +42,22 @@ final class Recorder {
     
     private func startRecordingInternal(_ durationProgressHandler: @escaping ProgressHandler) -> URL? {
         let settings: [String : Any] = [
-            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVFormatIDKey: Int(recorderSetting.audioFormatID),
             AVSampleRateKey: recorderSetting.sampleRate,
             AVNumberOfChannelsKey: recorderSetting.numberOfChannels,
+            AVEncoderBitRateKey: recorderSetting.encoderBitRateKey,
             AVLinearPCMBitDepthKey: recorderSetting.linearPCMBitDepth,
+            AVLinearPCMIsFloatKey: recorderSetting.linearPCMIsFloatKey,
+            AVLinearPCMIsBigEndianKey: recorderSetting.linearPCMIsBigEndianKey,
+            AVLinearPCMIsNonInterleaved: recorderSetting.linearPCMIsNonInterleaved,
             AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
         ]
 
         soundSamples = []
-        let recordingUrl = FileManager.tempAudioFile
+        guard let fileExt = fileExtension(for: recorderSetting.audioFormatID) else{
+            return nil
+        }
+        let recordingUrl = FileManager.tempDirPath.appendingPathComponent(UUID().uuidString + fileExt)
 
         do {
             try audioSession.setCategory(.record, mode: .default)
@@ -91,18 +98,71 @@ final class Recorder {
         audioTimer?.invalidate()
         audioTimer = nil
     }
+
+    private func fileExtension(for formatID: AudioFormatID) -> String? {
+        switch formatID {
+        case kAudioFormatMPEG4AAC:
+            return ".aac"
+        case kAudioFormatLinearPCM:
+            return ".wav"
+        case kAudioFormatMPEGLayer3:
+            return ".mp3"
+        case kAudioFormatAppleLossless:
+            return ".m4a"
+        case kAudioFormatOpus:
+            return ".opus"
+        case kAudioFormatAC3:
+            return ".ac3"
+        case kAudioFormatFLAC:
+            return ".flac"
+        case kAudioFormatAMR:
+            return ".amr"
+        case kAudioFormatMIDIStream:
+            return ".midi"
+        case kAudioFormatULaw:
+            return ".ulaw"
+        case kAudioFormatALaw:
+            return ".alaw"
+        case kAudioFormatAMR_WB:
+            return ".awb"
+        case kAudioFormatEnhancedAC3:
+            return ".eac3"
+        case kAudioFormatiLBC:
+            return ".ilbc"
+        default:
+            return nil
+        }
+    }
+
 }
 
 public struct RecorderSetting : Codable,Hashable {
-    
+    var audioFormatID: AudioFormatID
     var sampleRate: CGFloat
     var numberOfChannels: Int
+    var encoderBitRateKey: Int
+    // pcm
     var linearPCMBitDepth: Int
-    
-    public init(sampleRate: CGFloat = 12000, numberOfChannels: Int = 1, linearPCMBitDepth: Int = 16) {
+    var linearPCMIsFloatKey: Bool
+    var linearPCMIsBigEndianKey: Bool
+    var linearPCMIsNonInterleaved: Bool
+
+    public init(audioFormatID: AudioFormatID = kAudioFormatMPEG4AAC,
+                sampleRate: CGFloat = 12000,
+                numberOfChannels: Int = 1,
+                encoderBitRateKey: Int = 128,
+                linearPCMBitDepth: Int = 16,
+                linearPCMIsFloatKey: Bool = false,
+                linearPCMIsBigEndianKey: Bool = false,
+                linearPCMIsNonInterleaved: Bool = false) {
+        self.audioFormatID = audioFormatID
         self.sampleRate = sampleRate
         self.numberOfChannels = numberOfChannels
+        self.encoderBitRateKey = encoderBitRateKey
         self.linearPCMBitDepth = linearPCMBitDepth
+        self.linearPCMIsFloatKey = linearPCMIsFloatKey
+        self.linearPCMIsBigEndianKey = linearPCMIsBigEndianKey
+        self.linearPCMIsNonInterleaved = linearPCMIsNonInterleaved
     }
 }
 

--- a/Sources/ExyteChat/ChatView/Recording/RecordingPlayer.swift
+++ b/Sources/ExyteChat/ChatView/Recording/RecordingPlayer.swift
@@ -53,6 +53,27 @@ final class RecordingPlayer: ObservableObject {
         else { play() }
     }
 
+    func seek(with recording: Recording, to progress: Double) {
+        let goalTime = recording.duration * progress
+        if self.recording == nil {
+            self.recording = recording
+            if let url = recording.url {
+                setupPlayer(for: url, trackDuration: recording.duration)
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.player?.seek(to: CMTime(seconds: goalTime, preferredTimescale: 10))
+                if self?.playing == nil || self?.playing == false  {
+                    self?.play()
+                }
+            }
+            return
+        }
+        self.player?.seek(to: CMTime(seconds: goalTime, preferredTimescale: 10))
+        if !self.playing {
+            self.play()
+        }
+    }
+
     func seek(to progress: Double) {
         let goalTime = duration * progress
         player?.seek(to: CMTime(seconds: goalTime, preferredTimescale: 10))

--- a/Sources/ExyteChat/ChatView/Recording/RecordingPlayer.swift
+++ b/Sources/ExyteChat/ChatView/Recording/RecordingPlayer.swift
@@ -71,6 +71,7 @@ final class RecordingPlayer: ObservableObject {
         try? audioSession.setActive(true)
         player?.play()
         playing = true
+        NotificationCenter.default.post(name: .chatAudioIsPlaying, object: self)
     }
 
     private func setupPlayer(for url: URL, trackDuration: Double) {
@@ -83,6 +84,15 @@ final class RecordingPlayer: ObservableObject {
 
         let playerItem = AVPlayerItem(url: url)
         player = AVPlayer(playerItem: playerItem)
+        
+        NotificationCenter.default.addObserver(forName: .chatAudioIsPlaying, object: nil, queue: .main) { notification in
+            if let sender = notification.object as? RecordingPlayer {
+                if sender.recording?.url == self.recording?.url {
+                    return
+                }
+                self.pause()
+            }
+        }
 
         NotificationCenter.default.addObserver(
             forName: .AVPlayerItemDidPlayToEndTime,

--- a/Sources/ExyteChat/Extensions/DateFormatter+.swift
+++ b/Sources/ExyteChat/Extensions/DateFormatter+.swift
@@ -18,7 +18,6 @@ extension DateFormatter {
         let relativeDateFormatter = DateFormatter()
         relativeDateFormatter.timeStyle = .none
         relativeDateFormatter.dateStyle = .full
-        relativeDateFormatter.locale = Locale(identifier: "en_US")
         relativeDateFormatter.doesRelativeDateFormatting = true
 
         return relativeDateFormatter

--- a/Sources/ExyteChat/Extensions/Notification+.swift
+++ b/Sources/ExyteChat/Extensions/Notification+.swift
@@ -1,0 +1,12 @@
+//
+//  File.swift
+//  
+//
+//  Created by admin on 2024/9/17.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let chatAudioIsPlaying = Notification.Name("chatAudioIsPlaying")
+}

--- a/Sources/ExyteChat/Extensions/String+Size.swift
+++ b/Sources/ExyteChat/Extensions/String+Size.swift
@@ -7,6 +7,11 @@ import UIKit
 
 extension String {
 
+    static func localizedFormat(key: String, _ args: CVarArg...) -> String {
+        let localizedString = NSLocalizedString(key, comment: "")
+        return String(format: localizedString, arguments: args)
+    }
+
     static var markdownOptions = AttributedString.MarkdownParsingOptions(
         allowsExtendedAttributes: false,
         interpretedSyntax: .inlineOnlyPreservingWhitespace,

--- a/Sources/ExyteChat/Resources/en.lproj/Localizable.strings
+++ b/Sources/ExyteChat/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,26 @@
+/* 
+  Localizable.strings
+  
+
+  Created by admin on 2024/9/19.
+  
+*/
+
+// attachments directory
+"Unknown" = "Unknown";
+"Cancel" = "Cancel";
+"Recents" = "Recents";
+// inputView
+"Type a message..." = "Type a message...";
+"Add signature..." = "Add signature...";
+"Reply to %@" = "Reply to %@";
+"Recording..." = "Recording...";
+// messageView
+"Copy" = "Copy";
+"Reply" = "Reply";
+"Edit" = "Edit";
+"Delete" = "Delete";
+"Print" = "Print";
+
+"Waiting for network" = "Waiting for network";
+

--- a/Sources/ExyteChat/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/ExyteChat/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,26 @@
+/* 
+  Localizable.strings
+  
+
+  Created by admin on 2024/9/19.
+  
+*/
+
+// attachments directory
+"Unknown" = "未知";
+"Cancel" = "取消";
+"Recents" = "最近";
+// inputView
+"Type a message..." = "输入信息";
+"Add signature..." = "添加签名";
+"Reply to %@" = "回复 %@";
+"Recording..." = "录音中...";
+// messageView
+"Copy" = "复制";
+"Reply" = "回复";
+"Edit" = "修改";
+"Delete" = "删除";
+"Print" = "打印";
+
+"Waiting for network" = "等待网络...";
+


### PR DESCRIPTION
Fix: When the recording duration is too long (for example, 2 minutes), the waveform view exceeds the screen width. 
Fix:Only one audio should be played at the same time. 
New feature: add copy button to message action menu
New feature: supports audio play progress dragging.
New feature: support localizable.