### PR TITLE
Fix: Resolve jerky animations when updating message status during bubble movement

### DIFF
--- a/Sources/ExyteChat/ChatView/UIList.swift
+++ b/Sources/ExyteChat/ChatView/UIList.swift
@@ -253,7 +253,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
         case .insert(let section, let row):
             tableView.insertRows(at: [IndexPath(row: row, section: section)], with: animation)
         case .edit(let section, let row):
-            tableView.reloadRows(at: [IndexPath(row: row, section: section)], with: .none)
+            tableView.reconfigureRows(at: [IndexPath(row: row, section: section)])
         case .swap(let section, let rowFrom, let rowTo):
             tableView.deleteRows(at: [IndexPath(row: rowFrom, section: section)], with: animation)
             tableView.insertRows(at: [IndexPath(row: rowTo, section: section)], with: animation)


### PR DESCRIPTION
Hi!

I encountered lag issues when updating message statuses while they are animating. In my application, the transition between statuses (sending, undelivered, unread) takes about 200-300 ms.

To demonstrate this, I took the "Active Chat" example and reduced the message sending interval to 0.5 seconds:


![Before Fix](https://github.com/user-attachments/assets/b877fce9-db12-4bbb-b3ed-5c0bd7f5789e)

After the fix:

![QuickTime movie](https://github.com/user-attachments/assets/a8e590e3-2124-4a76-98e0-769797855286)

I used `reconfigureRows` (https://developer.apple.com/documentation/uikit/uitableview/3801923-reconfigurerows) instead of `reloadRows` in `UIList.swift`, which prevents the animation from being interrupted when updating the `MessageRow`.

Looking forward to your feedback!
