### PR TITLE
fix:fix update text bug

### DIFF
--- a/Sources/ExyteChat/Model/MessageRow.swift
+++ b/Sources/ExyteChat/Model/MessageRow.swift
@@ -65,6 +65,7 @@ struct MessageRow: Equatable {
         && lhs.commentsPosition == rhs.commentsPosition
         && lhs.message.status == rhs.message.status
         && lhs.message.triggerRedraw == rhs.message.triggerRedraw
+        && lhs.message.text == rhs.message.text
     }
 }
 


### PR DESCRIPTION
fix https://github.com/exyte/Chat/issues/104 https://github.com/exyte/Chat/issues/78

Here’s the translation for your PR submission:

---

The reason the UI did not update after the message was updated is due to the author's comparison logic.

**UIList.swift**

```swift
if context.coordinator.sections == sections {
    return
}
```

**MessagesSection.swift**

```swift
static func == (lhs: MessagesSection, rhs: MessagesSection) -> Bool {
    lhs.date == rhs.date && lhs.rows == rhs.rows
}
```

**MessageRow.swift**

```swift
static func == (lhs: Self, rhs: Self) -> Bool {
    lhs.id == rhs.id
    && lhs.positionInUserGroup == rhs.positionInUserGroup
    && lhs.commentsPosition == rhs.commentsPosition
    && lhs.message.status == rhs.message.status
    && lhs.message.triggerRedraw == rhs.message.triggerRedraw
}
```

At this point, we can identify the issue: Although the author included all fields in their response at [this link](https://github.com/exyte/Chat/issues/78#issuecomment-2251995947), the `MessageRow` did not account for one important field. As a result, the comparison of sections showed no changes, which prevented the update from being triggered.

**Modification:**

```swift
static func == (lhs: Self, rhs: Self) -> Bool {
    lhs.id == rhs.id
    && lhs.positionInUserGroup == rhs.positionInUserGroup
    && lhs.commentsPosition == rhs.commentsPosition
    && lhs.message.status == rhs.message.status
    && lhs.message.triggerRedraw == rhs.message.triggerRedraw
    && lhs.message.text == rhs.message.text // add this
}
```
