### PR TITLE
System Theme Support (Light/Dark Mode)

### DIFF
--- a/Example/ChatExample.xcodeproj/project.pbxproj
+++ b/Example/ChatExample.xcodeproj/project.pbxproj
@@ -467,7 +467,6 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Example/ChatExample/ContentView.swift
+++ b/Example/ChatExample/ContentView.swift
@@ -33,18 +33,18 @@ struct ContentView: View {
         }
         .navigationViewStyle(.stack)
         
-        .mediaPickerTheme(
-            main: .init(
-                text: .white,
-                albumSelectionBackground: .examplePickerBg,
-                fullscreenPhotoBackground: .examplePickerBg
-            ),
-            selection: .init(
-                emptyTint: .white,
-                emptyBackground: .black.opacity(0.25),
-                selectedTint: .exampleBlue,
-                fullscreenTint: .white
-            )
-        )
+//        .mediaPickerTheme(
+//            main: .init(
+//                text: .white,
+//                albumSelectionBackground: .examplePickerBg,
+//                fullscreenPhotoBackground: .examplePickerBg
+//            ),
+//            selection: .init(
+//                emptyTint: .white,
+//                emptyBackground: .black.opacity(0.25),
+//                selectedTint: .exampleBlue,
+//                fullscreenTint: .white
+//            )
+//        )
     }
 }

--- a/Example/ChatExample/Screens/ChatExampleView.swift
+++ b/Example/ChatExample/Screens/ChatExampleView.swift
@@ -33,7 +33,8 @@ struct ChatExampleView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button { presentationMode.wrappedValue.dismiss() } label: {
-                    Image("backArrow", bundle: .current)
+                    Image(systemName: "arrow.backward")
+                        .foregroundColor(.primary)
                 }
             }
 
@@ -58,10 +59,10 @@ struct ChatExampleView: View {
                         Text(viewModel.chatTitle)
                             .fontWeight(.semibold)
                             .font(.headline)
-                            .foregroundColor(.black)
+                            .foregroundColor(.primary)
                         Text(viewModel.chatStatus)
                             .font(.footnote)
-                            .foregroundColor(Color(hex: "AFB3B8"))
+                            .foregroundColor(.secondary)
                     }
                     Spacer()
                 }

--- a/Example/ChatExample/Screens/ChatExampleView.swift
+++ b/Example/ChatExample/Screens/ChatExampleView.swift
@@ -69,6 +69,7 @@ struct ChatExampleView: View {
                 .padding(.leading, 10)
             }
         }
+        .navigationBarTitleDisplayMode(.automatic)
         .onAppear(perform: viewModel.onStart)
         .onDisappear(perform: viewModel.onStop)
     }

--- a/Sources/ExyteChat/ChatView/Attachments/ActivityIndicator.swift
+++ b/Sources/ExyteChat/ChatView/Attachments/ActivityIndicator.swift
@@ -17,7 +17,7 @@ struct ActivityIndicator: View {
     var body: some View {
         ZStack {
             if showBackground {
-                Color.black.opacity(0.8)
+                Color(UIColor.secondarySystemBackground).opacity(0.8)
                     .frame(width: 100, height: 100)
                     .cornerRadius(8)
             }

--- a/Sources/ExyteChat/ChatView/Attachments/AttachmentsEditor.swift
+++ b/Sources/ExyteChat/ChatView/Attachments/AttachmentsEditor.swift
@@ -137,7 +137,7 @@ struct AttachmentsEditor<InputViewContent: View>: View {
                     inputViewModel.showPicker = false
                 } label: {
                     Text(localization.cancelButtonText)
-                        .foregroundColor(.white.opacity(0.7))
+                        .foregroundColor(.primary.opacity(0.7))
                 }
 
                 Spacer()
@@ -148,7 +148,7 @@ struct AttachmentsEditor<InputViewContent: View>: View {
                 Image(systemName: "chevron.down")
                     .rotationEffect(Angle(radians: showingAlbums ? .pi : 0))
             }
-            .foregroundColor(.white)
+            .foregroundColor(.primary)
             .onTapGesture {
                 withAnimation {
                     inputViewModel.mediaPickerMode = showingAlbums ? .photos : .albums

--- a/Sources/ExyteChat/ChatView/Attachments/AttachmentsGrid.swift
+++ b/Sources/ExyteChat/ChatView/Attachments/AttachmentsGrid.swift
@@ -64,8 +64,8 @@ struct AttachmentsGrid: View {
                                     ZStack {
                                         RadialGradient(
                                             colors: [
-                                                .black.opacity(0.8),
-                                                .black.opacity(0.6),
+                                                .secondary.opacity(0.7),
+                                                .secondary.opacity(0.3),
                                             ],
                                             center: .center,
                                             startRadius: 0,

--- a/Sources/ExyteChat/ChatView/Attachments/AttachmentsGrid.swift
+++ b/Sources/ExyteChat/ChatView/Attachments/AttachmentsGrid.swift
@@ -74,7 +74,7 @@ struct AttachmentsGrid: View {
                                         Text(hidden)
                                             .font(.body)
                                             .bold()
-                                            .foregroundColor(.white)
+                                            .foregroundColor(Color(UIColor.systemBackground))
                                     }
                                     .allowsHitTesting(false)
                                 }

--- a/Sources/ExyteChat/ChatView/Attachments/FullscreenMediaPages.swift
+++ b/Sources/ExyteChat/ChatView/Attachments/FullscreenMediaPages.swift
@@ -27,7 +27,7 @@ struct FullscreenMediaPages: View {
             }
 
         ZStack {
-            Color.black
+            Color(UIColor.systemBackground)
                 .opacity(max((200.0 - viewModel.offset.height) / 200.0, 0.5))
             VStack {
                 TabView(selection: $viewModel.index) {
@@ -78,7 +78,7 @@ struct FullscreenMediaPages: View {
                             }
                         }
                         .padding([.top, .horizontal], 12)
-                        .background(Color.black)
+                        .background(Color(UIColor.systemBackground))
                         .onAppear {
                             proxy.scrollTo(viewModel.index)
                         }
@@ -97,7 +97,7 @@ struct FullscreenMediaPages: View {
         .overlay(alignment: .top) {
             if viewModel.showMinis {
                 Text("\(viewModel.index + 1)/\(viewModel.attachments.count)")
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
                     .offset(y: safeAreaInsets.top)
             }
         }
@@ -107,7 +107,7 @@ struct FullscreenMediaPages: View {
                     theme.images.mediaPicker.cross
                         .padding(5)
                 }
-                .tint(.white)
+                .tint(.primary)
                 .padding(.leading, 15)
                 .offset(y: safeAreaInsets.top - 5)
             }
@@ -135,7 +135,7 @@ struct FullscreenMediaPages: View {
                             viewModel.toggleVideoMuted()
                         }
                 }
-                .foregroundColor(.white)
+                .foregroundColor(.primary)
                 .padding(.trailing, 10)
                 .offset(y: safeAreaInsets.top - 5)
             }

--- a/Sources/ExyteChat/ChatView/ChatView.swift
+++ b/Sources/ExyteChat/ChatView/ChatView.swift
@@ -252,6 +252,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
                         theme.images.scrollToBottom
                             .frame(width: 40, height: 40)
                             .circleBackground(theme.colors.friendMessage)
+                            .foregroundColor(.secondary)
                     }
                     .padding(8)
                 }

--- a/Sources/ExyteChat/ChatView/ChatView.swift
+++ b/Sources/ExyteChat/ChatView/ChatView.swift
@@ -222,7 +222,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
     var waitingForNetwork: some View {
         VStack {
             Rectangle()
-                .foregroundColor(.black.opacity(0.12))
+                .foregroundColor(.primary.opacity(0.12))
                 .frame(height: 1)
             HStack {
                 Spacer()
@@ -232,7 +232,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
             }
             .padding(.top, 6)
             Rectangle()
-                .foregroundColor(.black.opacity(0.12))
+                .foregroundColor(.primary.opacity(0.12))
                 .frame(height: 1)
         }
         .padding(.top, 8)

--- a/Sources/ExyteChat/ChatView/InputView/TextInputView.swift
+++ b/Sources/ExyteChat/ChatView/InputView/TextInputView.swift
@@ -23,7 +23,7 @@ struct TextInputView: View {
                 Text(localization.inputPlaceholder)
                     .foregroundColor(theme.colors.buttonBackground)
             }
-            .foregroundColor(style == .message ? theme.colors.textLightContext : theme.colors.textDarkContext)
+            .foregroundColor(.primary)
             .padding(.vertical, 10)
             .padding(.leading, !availableInput.isMediaAvailable ? 12 : 0)
             .onTapGesture {

--- a/Sources/ExyteChat/ChatView/MessageView/MessageMenu.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageMenu.swift
@@ -91,7 +91,6 @@ struct MessageMenu<MainButton: View, ActionEnum: MessageMenuAction>: View {
             ZStack {
                 theme.colors.friendMessage
                     .background(.ultraThinMaterial)
-                    .environment(\.colorScheme, .light)
                     .opacity(0.5)
                     .cornerRadius(12)
                 HStack {

--- a/Sources/ExyteChat/ChatView/MessageView/MessageTimeView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageTimeView.swift
@@ -13,7 +13,7 @@ struct MessageTimeView: View {
     var body: some View {
         Text(text)
             .font(.caption)
-            .foregroundColor(isCurrentUser ? chatTheme.colors.myMessageTime : chatTheme.colors.frientMessageTime)
+            .foregroundColor(isCurrentUser ? chatTheme.colors.myMessageTime : chatTheme.colors.friendMessageTime)
     }
 }
 

--- a/Sources/ExyteChat/Theme/ChatTheme.swift
+++ b/Sources/ExyteChat/Theme/ChatTheme.swift
@@ -104,7 +104,7 @@ public struct ChatTheme {
             textMediaPicker: Color = Color(UIColor.systemGray),
             recordDot: Color = Color(hex: "#F62121"),
             myMessageTime: Color = Color.white.opacity(0.4),
-            frientMessageTime: Color = Color.primary.opacity(0.4),
+            friendMessageTime: Color = Color.primary.opacity(0.4),
             timeCapsuleBackground: Color = Color(UIColor.systemBackground),
             timeCapsuleForeground: Color = Color.secondary
         ) {
@@ -124,7 +124,7 @@ public struct ChatTheme {
             self.textMediaPicker = textMediaPicker
             self.recordDot = recordDot
             self.myMessageTime = myMessageTime
-            self.frientMessageTime = frientMessageTime
+            self.friendMessageTime = friendMessageTime
             self.timeCapsuleBackground = timeCapsuleBackground
             self.timeCapsuleForeground = timeCapsuleForeground
         }

--- a/Sources/ExyteChat/Theme/ChatTheme.swift
+++ b/Sources/ExyteChat/Theme/ChatTheme.swift
@@ -260,8 +260,8 @@ public struct ChatTheme {
             backButton: Image? = nil,
             scrollToBottom: Image? = nil
         ) {
-            self.backButton = backButton ?? Image("backArrow", bundle: .current)
-            self.scrollToBottom = scrollToBottom ?? Image("scrollToBottom", bundle: .current)
+            self.backButton = backButton ?? Image(systemName: "arrow.backward")
+            self.scrollToBottom = scrollToBottom ?? Image(systemName: "chevron.down")
 
             self.attachMenu = AttachMenu(
                 camera: camera ?? Image("camera", bundle: .current),

--- a/Sources/ExyteChat/Theme/ChatTheme.swift
+++ b/Sources/ExyteChat/Theme/ChatTheme.swift
@@ -292,7 +292,7 @@ public struct ChatTheme {
             self.mediaPicker = MediaPicker(
                 chevronDown: chevronDown ?? Image("chevronDown", bundle: .current),
                 chevronRight: chevronRight ?? Image("chevronRight", bundle: .current),
-                cross: cross ?? Image("cross", bundle: .current)
+                cross: cross ?? Image(systemName: "xmark")
             )
 
             self.message = Message(

--- a/Sources/ExyteChat/Theme/ChatTheme.swift
+++ b/Sources/ExyteChat/Theme/ChatTheme.swift
@@ -33,6 +33,9 @@ public struct ChatTheme {
     public let colors: ChatTheme.Colors
     public let images: ChatTheme.Images
 
+    /// Exyte Chat Blue
+    public static let ChatBlue:Color = Color(hex: "#4962FF")
+    
     public init(colors: ChatTheme.Colors = .init(),
                 images: ChatTheme.Images = .init()) {
         self.colors = colors
@@ -85,25 +88,25 @@ public struct ChatTheme {
         public var timeCapsuleForeground: Color
 
         public init(
-            grayStatus: Color = Color(hex: "AFB3B8"),
+            grayStatus: Color = Color(UIColor.systemGray2),
             errorStatus: Color = Color.red,
-            inputLightContextBackground: Color = Color(hex: "F2F3F5"),
-            inputDarkContextBackground: Color = Color(hex: "F2F3F5").opacity(0.12),
-            mainBackground: Color = .white,
-            buttonBackground: Color = Color(hex: "989EAC"),
+            inputLightContextBackground: Color = Color(UIColor.secondarySystemBackground),
+            inputDarkContextBackground: Color = Color.primary.opacity(0.1),
+            mainBackground: Color = Color(UIColor.systemBackground),
+            buttonBackground: Color = Color(UIColor.secondaryLabel),
             addButtonBackground: Color = Color(hex: "#4F5055"),
-            sendButtonBackground: Color = Color(hex: "#4962FF"),
-            messageMenuBackground: Color = Color.white,
-            myMessage: Color = Color(hex: "4962FF"),
-            friendMessage: Color = Color(hex: "EBEDF0"),
-            textLightContext: Color = Color.black,
+            sendButtonBackground: Color = ChatTheme.ChatBlue,
+            messageMenuBackground: Color = Color(UIColor.systemBackground),
+            myMessage: Color = ChatTheme.ChatBlue,
+            friendMessage: Color = Color(UIColor.secondarySystemBackground),
+            textLightContext: Color = Color.primary,
             textDarkContext: Color = Color.white,
-            textMediaPicker: Color = Color(hex: "818C99"),
-            recordDot: Color = Color(hex: "F62121"),
-            myMessageTime: Color = .white.opacity(0.4),
-            frientMessageTime: Color = .black.opacity(0.4),
-            timeCapsuleBackground: Color = .black.opacity(0.4),
-            timeCapsuleForeground: Color = .white
+            textMediaPicker: Color = Color(UIColor.systemGray),
+            recordDot: Color = Color(hex: "#F62121"),
+            myMessageTime: Color = Color.white.opacity(0.4),
+            frientMessageTime: Color = Color.primary.opacity(0.4),
+            timeCapsuleBackground: Color = Color(UIColor.systemBackground),
+            timeCapsuleForeground: Color = Color.secondary
         ) {
             self.grayStatus = grayStatus
             self.errorStatus = errorStatus

--- a/Sources/ExyteChat/Theme/ChatTheme.swift
+++ b/Sources/ExyteChat/Theme/ChatTheme.swift
@@ -42,29 +42,46 @@ public struct ChatTheme {
     public struct Colors {
         public var grayStatus: Color
         public var errorStatus: Color
-
+        
+        /// Textfield background
         public var inputLightContextBackground: Color
+        /// Input dark context background
         public var inputDarkContextBackground: Color
 
+        /// Main ChatView background
         public var mainBackground: Color
+        /// Textfeild text color
         public var buttonBackground: Color
+        /// Add button background
         public var addButtonBackground: Color
+        /// Send / Record button background
         public var sendButtonBackground: Color
+        /// Long press message background
         public var messageMenuBackground: Color
 
+        /// Senders message bubble color
         public var myMessage: Color
+        /// Friends message text color
         public var friendMessage: Color
 
+        /// Friends message text color
         public var textLightContext: Color
+        /// Senders message text color
         public var textDarkContext: Color
+        /// Text media picker
         public var textMediaPicker: Color
 
+        /// Recording dot color
         public var recordDot: Color
 
+        /// Senders message time text color
         public var myMessageTime: Color
-        public var frientMessageTime: Color
-
+        /// Friends message time text color
+        public var friendMessageTime: Color
+        
+        /// Time capsule background color
         public var timeCapsuleBackground: Color
+        /// Time capsule foreground color
         public var timeCapsuleForeground: Color
 
         public init(


### PR DESCRIPTION
### What
This PR aims to provide support for automatic light / dark mode defined by iOS.

### Fixes
#27 

### Details
- Move from statically typed colors such as (.white and .black) to the dynamic system colors such as .primary and .systemBackground
- Move from bundled images to SFSymbols when possible (SFSymbols can be themed with the `foregroundColor` modifier) 

### Disclosure
- I tried my best to stick to the original themes but some views have changed / deviated from the original style. 
- Feel free to modify this PR as you see fit, or delete it, if it's out of scope. 
- I updated the `ChatExample` app to showcase the new theme, but I didn't adjust the `ChatFirestoreExample`

> [!WARNING]
> **Breaking Change** in 2b7f057635888580084fd30a946c0408a8bb41ea 
> Changed `frientMessageTime` -> `friendMessageTime`

Thanks for the awesome open source project!