### PR TITLE
Conditional MessageMenu Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,17 @@ enum Action: MessageMenuAction {
             Image(systemName: "square.and.pencil")
         }
     }
+    
+    // Optional
+    // Implement this method to conditionally include menu actions on a per message basis
+    // The default behavior is to include all menu action items
+    static func menuItems(for message: ExyteChat.Message) -> [Action] {
+        if message.user.isCurrentUser  {
+            return [.edit]
+        } else {
+            return [.reply]
+        }
+    }
 }
 
 ChatView(messages: viewModel.messages) { draft in

--- a/Sources/ExyteChat/ChatView/ChatView.swift
+++ b/Sources/ExyteChat/ChatView/ChatView.swift
@@ -379,6 +379,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
         MessageMenu(
             isShowingMenu: $isShowingMenu,
             menuButtonsSize: $menuButtonsSize,
+            message: row.message,
             alignment: row.message.user.isCurrentUser ? .right : .left,
             leadingPadding: avatarSize + MessageView.horizontalAvatarPadding * 2,
             trailingPadding: MessageView.statusViewSize + MessageView.horizontalStatusPadding,

--- a/Sources/ExyteChat/ChatView/MessageView/MessageMenu.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageMenu.swift
@@ -13,11 +13,11 @@ public protocol MessageMenuAction: Equatable, CaseIterable {
     func title() -> String
     func icon() -> Image
     
-    static func menuItems(for message:Message) -> [Self]
+    static func menuItems(for message: Message) -> [Self]
 }
 
 extension MessageMenuAction {
-    public static func menuItems(for message:Message) -> [Self] {
+    public static func menuItems(for message: Message) -> [Self] {
         Self.allCases.map { $0 }
     }
 }

--- a/Sources/ExyteChat/ChatView/MessageView/MessageMenu.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageMenu.swift
@@ -72,6 +72,7 @@ struct MessageMenu<MainButton: View, ActionEnum: MessageMenuAction>: View {
 
     @Binding var isShowingMenu: Bool
     @Binding var menuButtonsSize: CGSize
+    var message: Message
     var alignment: Alignment
     var leadingPadding: CGFloat
     var trailingPadding: CGFloat
@@ -90,7 +91,7 @@ struct MessageMenu<MainButton: View, ActionEnum: MessageMenuAction>: View {
     var body: some View {
         FloatingButton(
             mainButtonView: mainButton().allowsHitTesting(false),
-            buttons: ActionEnum.allCases.map {
+            buttons: ActionEnum.menuItems(for: message).map {
                 menuButton(title: $0.title(), icon: $0.icon(), action: $0)
             },
             isOpen: $isShowingMenu

--- a/Sources/ExyteChat/ChatView/MessageView/MessageMenu.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageMenu.swift
@@ -12,6 +12,14 @@ import enum FloatingButton.Alignment
 public protocol MessageMenuAction: Equatable, CaseIterable {
     func title() -> String
     func icon() -> Image
+    
+    static func menuItems(for message:Message) -> [Self]
+}
+
+extension MessageMenuAction {
+    public static func menuItems(for message:Message) -> [Self] {
+        Self.allCases.map { $0 }
+    }
 }
 
 public enum DefaultMessageMenuAction: MessageMenuAction {

--- a/Sources/ExyteChat/ChatView/MessageView/MessageMenu.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageMenu.swift
@@ -64,6 +64,14 @@ public enum DefaultMessageMenuAction: MessageMenuAction {
     public static var allCases: [DefaultMessageMenuAction] = [
         .copy, .reply, .edit(saveClosure: {_ in})
     ]
+    
+    static public func menuItems(for message: Message) -> [DefaultMessageMenuAction] {
+        if message.user.isCurrentUser {
+            return allCases
+        } else {
+            return [.copy, .reply]
+        }
+    }
 }
 
 struct MessageMenu<MainButton: View, ActionEnum: MessageMenuAction>: View {


### PR DESCRIPTION
### What:
- Adds a static method to the `MessageMenuAction` protocol that allows for a user to return a custom list of MenuItems for a given message.

```swift
public protocol MessageMenuAction: Equatable, CaseIterable {
    func title() -> String
    func icon() -> Image
    
    // Added
    static func menuItems(for message: Message) -> [Self]
}

extension MessageMenuAction {
    // Default implementation maintains current behavior by returning allCases
    public static func menuItems(for message: Message) -> [Self] {
        Self.allCases.map { $0 }
    }
}
``` 

### Fixes:
#83 

### Disclosure:
- Feel free to modify this PR or delete it if deemed out of scope.
