### PR TITLE
Make links underlined instead of blue

### DIFF
--- a/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
@@ -158,8 +158,11 @@ struct MessageView: View {
             }
 
             if !message.text.isEmpty {
-                MessageTextView(text: message.text, messageUseMarkdown: messageUseMarkdown)
-                    .padding(.horizontal, MessageView.horizontalTextPadding)
+                MessageTextView(
+                    text: message.text, messageUseMarkdown: messageUseMarkdown,
+                    isCurrentUser: message.user.isCurrentUser
+                )
+                .padding(.horizontal, MessageView.horizontalTextPadding)
             }
 
             if let recording = message.recording {
@@ -210,9 +213,12 @@ struct MessageView: View {
 
     @ViewBuilder
     func textWithTimeView(_ message: Message) -> some View {
-        let messageView = MessageTextView(text: message.text, messageUseMarkdown: messageUseMarkdown)
-            .fixedSize(horizontal: false, vertical: true)
-            .padding(.horizontal, MessageView.horizontalTextPadding)
+        let messageView = MessageTextView(
+            text: message.text, messageUseMarkdown: messageUseMarkdown,
+            isCurrentUser: message.user.isCurrentUser
+        )
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(.horizontal, MessageView.horizontalTextPadding)
 
         let timeView = messageTimeView()
             .padding(.trailing, 12)


### PR DESCRIPTION
By default, Apple will highlight links blue. However, this makes links sent by us difficult to read, when using the default theme. Therefore, underline links, without changing their color.

This change requires us to pull the markdown logic out of `MessageTextView`. This is because, when styling the text, we need to know whether to use the foreground or background color in the text, depending on the message type. This information is not available in `MessageTextView` - therefore we change it to take the `AttributedString` directly.

I would have preferred to keep the `AttributedString` logic in `MessageTextView` and clear the `foregroundColor` - however this didn't work, even when using `NSAttributedString`'s `removeAttribute(_:range:)` method. So, this seems to me to be the cleanest way to do it.

I hope this is useful! If you have any feedback or things to improve, please let me know. Have a good day :)

Before:

<img width="484" alt="original-link" src="https://github.com/user-attachments/assets/9e749f76-d0c7-4254-ae79-eb2a0815a59a" />

After:

<img width="489" alt="underlined-link" src="https://github.com/user-attachments/assets/1cbfbaa9-7ed3-4dd1-b2b2-d6a059458e09" />
