### PR TITLE
Added reply bubble opacity parameter

### DIFF
--- a/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
@@ -100,7 +100,7 @@ struct MessageView: View {
             VStack(alignment: message.user.isCurrentUser ? .trailing : .leading, spacing: 2) {
                 if !isDisplayingMessageMenu, let reply = message.replyMessage?.toMessage() {
                     replyBubbleView(reply)
-                        .opacity(0.5)
+                        .opacity(theme.style.replyOpacity)
                         .padding(message.user.isCurrentUser ? .trailing : .leading, 10)
                         .overlay(alignment: message.user.isCurrentUser ? .trailing : .leading) {
                             Capsule()
@@ -309,8 +309,8 @@ extension View {
             .background {
                 if isReply || !message.text.isEmpty || message.recording != nil {
                     RoundedRectangle(cornerRadius: radius)
-                        .opacity(isReply ? 0.5 : 1)
                         .foregroundColor(theme.colors.messageBG(message.user.type))
+                        .opacity(isReply ? theme.style.replyOpacity : 1)
                 }
             }
             .cornerRadius(radius)

--- a/Sources/ExyteChat/Theme/ChatTheme.swift
+++ b/Sources/ExyteChat/Theme/ChatTheme.swift
@@ -49,13 +49,16 @@ extension View {
 public struct ChatTheme {
     public let colors: ChatTheme.Colors
     public let images: ChatTheme.Images
+    public let style: ChatTheme.Style
 
     public init(
         colors: ChatTheme.Colors = .init(),
-        images: ChatTheme.Images = .init()
+        images: ChatTheme.Images = .init(),
+        style: ChatTheme.Style = .init()
     ) {
         self.colors = colors
         self.images = images
+        self.style = style
     }
     
     internal init(accentColor: Color) {
@@ -374,6 +377,14 @@ public struct ChatTheme {
                 cancelReply: cancelReply ?? Image(systemName: "x.circle"),
                 replyToMessage: replyToMessage ?? Image(systemName: "arrow.uturn.left")
             )
+        }
+    }
+    
+    public struct Style {
+        public var replyOpacity: Double
+        
+        public init(replyOpacity: Double = 0.5) {
+            self.replyOpacity = replyOpacity
         }
     }
 }


### PR DESCRIPTION
There’s one more tiny fix. If the sender's message background is dark and the foreground is light, an opacity of 0.5 can affect visibility. It’s better to use 0.8 or something similar. Not sure if it deserves a separate struct, though, but I don’t see any reason to put it in Colors.
Example with 0.8: 
<img width="411" alt="image" src="https://github.com/user-attachments/assets/f6cc48e6-7a79-4d09-bc37-02266fe83e9e" />
And default 0.5:
<img width="405" alt="image" src="https://github.com/user-attachments/assets/4af7d840-391c-4df8-9778-cc3be9082637" />

