### PR TITLE
Ensure date view is next to messages of that date

### DIFF
--- a/Example/ChatExample/Screens/CommentsExampleView.swift
+++ b/Example/ChatExample/Screens/CommentsExampleView.swift
@@ -64,7 +64,9 @@ struct CommentsExampleView: View {
 
             ChatView(messages: viewModel.messages, chatType: .comments, replyMode: .answer) { draft in
                 viewModel.send(draft: draft)
-            } messageBuilder: { message, positionInGroup, positionInCommentsGroup, showContextMenuClosure, messageActionClosure, showAttachmentClosure in
+            } messageBuilder: {
+                message, positionInGroup, positionInMessagesSection, positionInCommentsGroup,
+                showContextMenuClosure, messageActionClosure, showAttachmentClosure in
                 messageCell(message, positionInCommentsGroup, showMenuClosure: showContextMenuClosure, actionClosure: messageActionClosure, attachmentClosure: showAttachmentClosure)
             } messageMenuAction: { (action: Action, defaultActionClosure, message) in
                 switch action {

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You may customize message cells like this:
 ```swift
 ChatView(messages: viewModel.messages) { draft in
     viewModel.send(draft: draft)
-} messageBuilder: { message, positionInUserGroup, positionInCommentsGroup, showContextMenuClosure, messageActionClosure, showAttachmentClosure in
+} messageBuilder: { message, positionInUserGroup, positionInMessagesSection, positionInCommentsGroup, showContextMenuClosure, messageActionClosure, showAttachmentClosure in
     VStack {
         Text(message.text)
         if !message.attachments.isEmpty {
@@ -109,6 +109,7 @@ ChatView(messages: viewModel.messages) { draft in
 `messageBuilder`'s parameters:  
 - `message` - the message containing user info, attachments, etc.   
 - `positionInUserGroup` - the position of the message in its continuous collection of messages from the same user    
+- `positionInMessagesSection` position of message in the section of messages from that day
 - `positionInCommentsGroup` - position of message in its continuous group of comments (only works for .answer ReplyMode, nil for .quote mode)  
 - `showContextMenuClosure` - closure to show message context menu   
 - `messageActionClosure ` - closure to pass user interaction, .reply for example   

--- a/Sources/ExyteChat/ChatView/ChatView.swift
+++ b/Sources/ExyteChat/ChatView/ChatView.swift
@@ -26,6 +26,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
     /// To build a custom message view use the following parameters passed by this closure:
     /// - message containing user, attachments, etc.
     /// - position of message in its continuous group of messages from the same user
+    /// - position of message in the section of messages from that day
     /// - position of message in its continuous group of comments (only works for .answer ReplyMode, nil for .quote mode)
     /// - closure to show message context menu
     /// - closure to pass user interaction, .reply for example
@@ -33,6 +34,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
     public typealias MessageBuilderClosure = ((
         _ message: Message,
         _ positionInGroup: PositionInUserGroup,
+        _ positionInMessagesSection: PositionInMessagesSection,
         _ positionInCommentsGroup: CommentsPosition?,
         _ showContextMenuClosure: @escaping () -> Void,
         _ messageActionClosure: @escaping (Message, DefaultMessageMenuAction) -> Void,

--- a/Sources/ExyteChat/ChatView/MessageView/ChatMessageView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/ChatMessageView.swift
@@ -40,6 +40,7 @@ struct ChatMessageView<MessageContent: View>: View {
                     viewModel: viewModel,
                     message: row.message,
                     positionInUserGroup: row.positionInUserGroup,
+                    positionInMessagesSection: row.positionInMessagesSection,
                     chatType: chatType,
                     avatarSize: avatarSize,
                     tapAvatarClosure: tapAvatarClosure,

--- a/Sources/ExyteChat/ChatView/MessageView/ChatMessageView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/ChatMessageView.swift
@@ -30,6 +30,7 @@ struct ChatMessageView<MessageContent: View>: View {
                 messageBuilder(
                     row.message,
                     row.positionInUserGroup,
+                    row.positionInMessagesSection,
                     row.commentsPosition,
                     { viewModel.messageMenuRow = row },
                     viewModel.messageMenuAction()) { attachment in

--- a/Sources/ExyteChat/ChatView/MessageView/MessageMenu/MessageMenu.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageMenu/MessageMenu.swift
@@ -267,7 +267,7 @@ struct MessageMenu<MainButton: View, ActionEnum: MessageMenuAction>: View {
             )
             
             messageTopPadding = cellFrame.height - messageFrame.height
-            if !message.reactions.isEmpty { messageTopPadding = positionInUserGroup == .single || positionInUserGroup == .first ? 8 : 4 }
+            if !message.reactions.isEmpty { messageTopPadding = positionInUserGroup.isTop ? 8 : 4 }
             
             /// Calculate our vertical safe area insets
             let safeArea = safeAreaInsets.top + safeAreaInsets.bottom

--- a/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
@@ -81,8 +81,8 @@ struct MessageView: View {
     }
 
     var topPadding: CGFloat {
-        let bubbleOffset = bubbleSize.height / 1.5
-        if chatType == .comments { return 0 }
+        let bubbleOffset = message.reactions.isEmpty ? 0 : bubbleSize.height / 1.5
+        if chatType == .comments { return bubbleOffset }
         var amount: CGFloat = positionInUserGroup.isTop && !positionInMessagesSection.isTop ? 8 : 4
         if !message.reactions.isEmpty { amount += bubbleOffset }
         return amount

--- a/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
@@ -81,14 +81,14 @@ struct MessageView: View {
 
     var topPadding: CGFloat {
         if chatType == .comments { return 0 }
-        var amount:CGFloat = positionInUserGroup == .single || positionInUserGroup == .first ? 8 : 4
+        var amount: CGFloat = positionInUserGroup.isTop ? 8 : 4
         if !message.reactions.isEmpty { amount += (bubbleSize.height / 1.5) }
         return amount
     }
 
     var bottomPadding: CGFloat {
         if chatType == .conversation { return 0 }
-        return positionInUserGroup == .single || positionInUserGroup == .first ? 8 : 4
+        return positionInUserGroup.isTop ? 8 : 4
     }
 
     var body: some View {

--- a/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
@@ -80,9 +80,10 @@ struct MessageView: View {
     }
 
     var topPadding: CGFloat {
+        let bubbleOffset = bubbleSize.height / 1.5
         if chatType == .comments { return 0 }
         var amount: CGFloat = positionInUserGroup.isTop ? 8 : 4
-        if !message.reactions.isEmpty { amount += (bubbleSize.height / 1.5) }
+        if !message.reactions.isEmpty { amount += bubbleOffset }
         return amount
     }
 

--- a/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
@@ -83,7 +83,7 @@ struct MessageView: View {
     var topPadding: CGFloat {
         let bubbleOffset = bubbleSize.height / 1.5
         if chatType == .comments { return 0 }
-        var amount: CGFloat = positionInUserGroup.isTop ? 8 : 4
+        var amount: CGFloat = positionInUserGroup.isTop && !positionInMessagesSection.isTop ? 8 : 4
         if !message.reactions.isEmpty { amount += bubbleOffset }
         return amount
     }

--- a/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
@@ -15,6 +15,7 @@ struct MessageView: View {
 
     let message: Message
     let positionInUserGroup: PositionInUserGroup
+    let positionInMessagesSection: PositionInMessagesSection
     let chatType: ChatType
     let avatarSize: CGFloat
     let tapAvatarClosure: ChatView.TapAvatarClosure?
@@ -365,6 +366,7 @@ struct MessageView_Preview: PreviewProvider {
                 viewModel: ChatViewModel(),
                 message: replyedMessage,
                 positionInUserGroup: .single,
+                positionInMessagesSection: .single,
                 chatType: .conversation,
                 avatarSize: 32,
                 tapAvatarClosure: nil,

--- a/Sources/ExyteChat/ChatView/UIList.swift
+++ b/Sources/ExyteChat/ChatView/UIList.swift
@@ -527,7 +527,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
                 } else {
                     Text(sections[section].formattedDate)
                         .font(.system(size: 11))
-                        .padding(10)
+                        .padding(.top, 30)
                         .padding(.bottom, 8)
                         .foregroundColor(.gray)
                 }

--- a/Sources/ExyteChat/ChatView/UIList.swift
+++ b/Sources/ExyteChat/ChatView/UIList.swift
@@ -581,7 +581,9 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
 
     func formatRow(_ row: MessageRow) -> String {
         if let status = row.message.status {
-            return String("id: \(row.id) text: \(row.message.text) status: \(status) date: \(row.message.createdAt) position: \(row.positionInUserGroup) trigger: \(row.message.triggerRedraw)")
+            return String(
+                "id: \(row.id) text: \(row.message.text) status: \(status) date: \(row.message.createdAt) position in user group: \(row.positionInUserGroup) position in messages section: \(row.positionInMessagesSection) trigger: \(row.message.triggerRedraw)"
+            )
         }
         return ""
     }

--- a/Sources/ExyteChat/ChatView/WrappingMessages.swift
+++ b/Sources/ExyteChat/ChatView/WrappingMessages.swift
@@ -111,10 +111,21 @@ extension ChatView {
                     positionInUserGroup = .last
                 }
 
+                let positionInMessagesSection: PositionInMessagesSection
+                if messages.count == 1 {
+                    positionInMessagesSection = .single
+                } else if !prevMessageExists {
+                    positionInMessagesSection = .first
+                } else if !nextMessageExists {
+                    positionInMessagesSection = .last
+                } else {
+                    positionInMessagesSection = .middle
+                }
+
                 if replyMode == .quote {
                     return MessageRow(
                         message: $0.element, positionInUserGroup: positionInUserGroup,
-                        commentsPosition: nil)
+                        positionInMessagesSection: positionInMessagesSection, commentsPosition: nil)
                 }
 
                 let nextMessageIsAReply = nextMessage?.replyMessage != nil
@@ -164,6 +175,7 @@ extension ChatView {
 
                 return MessageRow(
                     message: $0.element, positionInUserGroup: positionInUserGroup,
+                    positionInMessagesSection: positionInMessagesSection,
                     commentsPosition: commentsPosition)
             }
             .reversed()

--- a/Sources/ExyteChat/ChatView/WrappingMessages.swift
+++ b/Sources/ExyteChat/ChatView/WrappingMessages.swift
@@ -100,19 +100,21 @@ extension ChatView {
                 let nextMessageIsSameUser = nextMessage?.user.id == message.user.id
                 let prevMessageIsSameUser = prevMessage?.user.id == message.user.id
 
-                let position: PositionInUserGroup
+                let positionInUserGroup: PositionInUserGroup
                 if nextMessageExists, nextMessageIsSameUser, prevMessageIsSameUser {
-                    position = .middle
+                    positionInUserGroup = .middle
                 } else if !nextMessageExists || !nextMessageIsSameUser, !prevMessageIsSameUser {
-                    position = .single
+                    positionInUserGroup = .single
                 } else if nextMessageExists, nextMessageIsSameUser {
-                    position = .first
+                    positionInUserGroup = .first
                 } else {
-                    position = .last
+                    positionInUserGroup = .last
                 }
 
                 if replyMode == .quote {
-                    return MessageRow(message: $0.element, positionInUserGroup: position, commentsPosition: nil)
+                    return MessageRow(
+                        message: $0.element, positionInUserGroup: positionInUserGroup,
+                        commentsPosition: nil)
                 }
 
                 let nextMessageIsAReply = nextMessage?.replyMessage != nil
@@ -156,9 +158,13 @@ extension ChatView {
                     positionInChat = .middle
                 }
 
-                let commentsPosition = CommentsPosition(inCommentsGroup: positionInComments, inSection: positionInSection, inChat: positionInChat)
+                let commentsPosition = CommentsPosition(
+                    inCommentsGroup: positionInComments, inSection: positionInSection,
+                    inChat: positionInChat)
 
-                return MessageRow(message: $0.element, positionInUserGroup: position, commentsPosition: commentsPosition)
+                return MessageRow(
+                    message: $0.element, positionInUserGroup: positionInUserGroup,
+                    commentsPosition: commentsPosition)
             }
             .reversed()
     }

--- a/Sources/ExyteChat/Model/MessageRow.swift
+++ b/Sources/ExyteChat/Model/MessageRow.swift
@@ -9,6 +9,10 @@ public enum PositionInUserGroup { // group from the same user
     case middle
     case last
     case single // the only message in its group
+
+    var isTop: Bool {
+        self == .first || self == .single
+    }
 }
 
 // for comments reply mode only

--- a/Sources/ExyteChat/Model/MessageRow.swift
+++ b/Sources/ExyteChat/Model/MessageRow.swift
@@ -15,6 +15,17 @@ public enum PositionInUserGroup { // group from the same user
     }
 }
 
+public enum PositionInMessagesSection { // messages within the same day
+    case first
+    case middle
+    case last
+    case single
+
+    var isTop: Bool {
+        self == .first || self == .single
+    }
+}
+
 // for comments reply mode only
 
 public struct CommentsPosition: Equatable {
@@ -61,11 +72,13 @@ public enum PositionInChat {
 struct MessageRow: Equatable {
     let message: Message
     let positionInUserGroup: PositionInUserGroup
+    let positionInMessagesSection: PositionInMessagesSection
     let commentsPosition: CommentsPosition?
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.id == rhs.id
         && lhs.positionInUserGroup == rhs.positionInUserGroup
+        && lhs.positionInMessagesSection == rhs.positionInMessagesSection
         && lhs.commentsPosition == rhs.commentsPosition
         && lhs.message.status == rhs.message.status
         && lhs.message.triggerRedraw == rhs.message.triggerRedraw

--- a/Tests/ExyteChatTests/WrappingMessagesTest.swift
+++ b/Tests/ExyteChatTests/WrappingMessagesTest.swift
@@ -23,7 +23,7 @@ extension Tag {
     @Tag static var messageOrder: Self
     @Tag static var answerMode: Self
     @Tag static var quoteMode: Self
-    @Tag static var positionInUserGroup: Self
+    @Tag static var positionInUserGroupAndMessagesSection: Self
     @Tag static var positionInCommentsGroup: Self
 }
 
@@ -221,7 +221,8 @@ struct WrappingMessagesTest {
     }
 
     @Test(
-        "Single message has single position in user group", .tags(.positionInUserGroup),
+        "Single message has single position in user group",
+        .tags(.positionInUserGroupAndMessagesSection),
         arguments: ChatType.allCases, ReplyMode.allCases)
     func singleMessageHasSinglePositionInUserGroup(for chatType: ChatType, and replyMode: ReplyMode)
         async throws
@@ -235,11 +236,13 @@ struct WrappingMessagesTest {
         #expect(sections.first?.rows.first?.id == singleMessage.id)
 
         #expect(sections.first?.rows.first?.positionInUserGroup == .single)
+        #expect(sections.first?.rows.first?.positionInMessagesSection == .single)
     }
 
     @Test(
         "Multiple messages from single user have top, middle and bottom positions in user group",
-        .tags(.positionInUserGroup), arguments: ChatType.allCases, ReplyMode.allCases)
+        .tags(.positionInUserGroupAndMessagesSection), arguments: ChatType.allCases,
+        ReplyMode.allCases)
     func multipleMessagesFromSingleUserHaveCorrectUserGroupPositions(
         for chatType: ChatType, and replyMode: ReplyMode
     ) async throws {
@@ -262,18 +265,29 @@ struct WrappingMessagesTest {
         switch chatType {
         case .comments:
             #expect(sections.first?.rows[0].positionInUserGroup == .first)
+            #expect(sections.first?.rows[0].positionInMessagesSection == .first)
+
             #expect(sections.first?.rows[1].positionInUserGroup == .middle)
+            #expect(sections.first?.rows[1].positionInMessagesSection == .middle)
+
             #expect(sections.first?.rows[2].positionInUserGroup == .last)
+            #expect(sections.first?.rows[2].positionInMessagesSection == .last)
         case .conversation:
             #expect(sections.first?.rows[2].positionInUserGroup == .first)
+            #expect(sections.first?.rows[2].positionInMessagesSection == .first)
+
             #expect(sections.first?.rows[1].positionInUserGroup == .middle)
+            #expect(sections.first?.rows[1].positionInMessagesSection == .middle)
+
             #expect(sections.first?.rows[0].positionInUserGroup == .last)
+            #expect(sections.first?.rows[0].positionInMessagesSection == .last)
         }
     }
 
     @Test(
         "Message from another user, in between many messages by another, splits the user group",
-        .tags(.positionInUserGroup), arguments: ChatType.allCases, ReplyMode.allCases)
+        .tags(.positionInUserGroupAndMessagesSection), arguments: ChatType.allCases,
+        ReplyMode.allCases)
     func messageFromAnotherUserSplitsUserGroup(for chatType: ChatType, and replyMode: ReplyMode)
         async throws
     {
@@ -297,22 +311,41 @@ struct WrappingMessagesTest {
         switch chatType {
         case .comments:
             #expect(sections.first?.rows[0].positionInUserGroup == .first)
+            #expect(sections.first?.rows[0].positionInMessagesSection == .first)
+
             #expect(sections.first?.rows[1].positionInUserGroup == .last)
+            #expect(sections.first?.rows[1].positionInMessagesSection == .middle)
+
             #expect(sections.first?.rows[2].positionInUserGroup == .single)
+            #expect(sections.first?.rows[2].positionInMessagesSection == .middle)
+
             #expect(sections.first?.rows[3].positionInUserGroup == .first)
+            #expect(sections.first?.rows[3].positionInMessagesSection == .middle)
+
             #expect(sections.first?.rows[4].positionInUserGroup == .last)
+            #expect(sections.first?.rows[4].positionInMessagesSection == .last)
         case .conversation:
             #expect(sections.first?.rows[4].positionInUserGroup == .first)
+            #expect(sections.first?.rows[4].positionInMessagesSection == .first)
+
             #expect(sections.first?.rows[3].positionInUserGroup == .last)
+            #expect(sections.first?.rows[3].positionInMessagesSection == .middle)
+
             #expect(sections.first?.rows[2].positionInUserGroup == .single)
+            #expect(sections.first?.rows[2].positionInMessagesSection == .middle)
+
             #expect(sections.first?.rows[1].positionInUserGroup == .first)
+            #expect(sections.first?.rows[1].positionInMessagesSection == .middle)
+
             #expect(sections.first?.rows[0].positionInUserGroup == .last)
+            #expect(sections.first?.rows[0].positionInMessagesSection == .last)
         }
     }
 
     @Test(
         "Messages from the same user on different days should not be in the same user group",
-        .tags(.positionInUserGroup), arguments: ChatType.allCases, ReplyMode.allCases)
+        .tags(.positionInUserGroupAndMessagesSection), arguments: ChatType.allCases,
+        ReplyMode.allCases)
     func messagesOnDifferentDaysShouldBeInDifferentUserGroups(
         for chatType: ChatType, and replyMode: ReplyMode
     ) async throws {
@@ -329,7 +362,10 @@ struct WrappingMessagesTest {
         #expect(sections[0].rows.first?.id == message1.id)
 
         #expect(sections[1].rows.first?.positionInUserGroup == .single)
+        #expect(sections[1].rows.first?.positionInMessagesSection == .single)
+
         #expect(sections[0].rows.first?.positionInUserGroup == .single)
+        #expect(sections[0].rows.first?.positionInMessagesSection == .single)
     }
 
     @Test(


### PR DESCRIPTION
Previously, the date view could appear closer to the previous date's messages, particularly in conversation mode. This could cause users to think that the date view was referring to the message on the previous, instead of the given, date.

Additionally, fix a bug causing reactions on the first message of the section to get truncated.

| Mode | Before | After |
| ---- | ------ | ----- |
| Conversation | <img width="405" alt="before-conversation" src="https://github.com/user-attachments/assets/5123676f-c9d3-46c9-b2b1-2d523cfc537b" /> | <img width="404" alt="after-conversation" src="https://github.com/user-attachments/assets/27302714-6848-4b00-b1af-4e2b59049b38" /> |
| Comments | <img width="406" alt="before-comments" src="https://github.com/user-attachments/assets/137d32c0-a039-4d7b-9bf1-079871bc6078" /> | <img width="407" alt="after-comments" src="https://github.com/user-attachments/assets/cff646fe-7fa4-4370-95b5-87e6ce1f70bd" /> |