### PR TITLE
Removed ZStack from message bubble

### DIFF
--- a/Sources/ExyteChat/ChatView/MessageView/MessageMenu/MessageMenu.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageMenu/MessageMenu.swift
@@ -266,8 +266,7 @@ struct MessageMenu<MainButton: View, ActionEnum: MessageMenuAction>: View {
                 height: viewModel.messageFrame.height
             )
             
-            messageTopPadding = cellFrame.height - messageFrame.height
-            if !message.reactions.isEmpty { messageTopPadding = positionInUserGroup.isTop ? 8 : 4 }
+            messageTopPadding = 4
             
             /// Calculate our vertical safe area insets
             let safeArea = safeAreaInsets.top + safeAreaInsets.bottom

--- a/Sources/ExyteChat/ChatView/MessageView/MessageReactionView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageReactionView.swift
@@ -40,7 +40,7 @@ extension MessageView {
         }
         .offset(
             x: message.user.isCurrentUser ? -(bubbleSize.height / 2) : (bubbleSize.height / 2),
-            y: -(bubbleSize.height / 1.5)
+            y: 0
         )
     }
     


### PR DESCRIPTION
It seems like ZStack doesn't do its job with short messages. I propose removing it and placing reactions as an overlay.

|Before | After|
|-------|------|
|<img src="https://github.com/user-attachments/assets/2100d356-1125-4945-a5b3-492bc7aaf607" width=300> | <img src="https://github.com/user-attachments/assets/4954d628-aa07-49d6-8f17-da6bb5cb36ce" width=300> |
