### PR TITLE
Allow arbitrarily styled text (including links)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 - Can display a fullscreen menu on long press a message cell (automatically shows scroll for big messages)
 - Supports "reply to message" via message menu or through a closure. Remove and edit are **coming soon**
 - This library allows to send the following content in messages in any combination:
-    - Text with/without markdown
+    - Arbitrarily styled text with `AttributedString` or markdown
     - Photo/video
     - Audio recording
     **Coming soon:**
@@ -277,6 +277,7 @@ Please use `mediaPickerTheme` in a similar fashion to customize the built-in pho
 `avatarSize` - the default avatar is a circle, you can specify its diameter here 
 `tapAvatarClosure` - closure to call on avatar tap   
 `messageUseMarkdown` - use markdown (e.g. ** to make something bold) or not
+`messageUseStyler` - pass a function that converts the message's `String` to the styled `AttributedString`
 `showMessageTimeView` - show timestamp in a corner of the message   
 `setMessageFont` - pass custom font to use for messages   
 

--- a/Sources/ExyteChat/ChatView/Attachments/AttachmentsEditor.swift
+++ b/Sources/ExyteChat/ChatView/Attachments/AttachmentsEditor.swift
@@ -23,7 +23,7 @@ struct AttachmentsEditor<InputViewContent: View>: View {
 
     var inputViewBuilder: InputViewBuilderClosure?
     var chatTitle: String?
-    var messageUseMarkdown: Bool
+    var messageStyler: (String) -> AttributedString
     var orientationHandler: MediaPickerOrientationHandler
     var mediaPickerSelectionParameters: MediaPickerParameters?
     var availableInputs: [AvailableInputType]
@@ -136,7 +136,7 @@ struct AttachmentsEditor<InputViewContent: View>: View {
                     inputFieldId: UUID(),
                     style: .signature,
                     availableInputs: availableInputs,
-                    messageUseMarkdown: messageUseMarkdown,
+                    messageStyler: messageStyler,
                     localization: localization
                 )
             }

--- a/Sources/ExyteChat/ChatView/ChatView.swift
+++ b/Sources/ExyteChat/ChatView/ChatView.swift
@@ -112,7 +112,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
     var showDateHeaders: Bool = true
     var isScrollEnabled: Bool = true
     var avatarSize: CGFloat = 32
-    var messageUseMarkdown: Bool = false
+    var messageStyler: (String) -> AttributedString = AttributedString.init
     var showMessageMenuOnLongPress: Bool = true
     var messageMenuAnimationDuration: Double = 0.3
     var showNetworkConnectionProblem: Bool = false
@@ -223,7 +223,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
                     inputViewModel: inputViewModel,
                     inputViewBuilder: inputViewBuilder,
                     chatTitle: chatTitle,
-                    messageUseMarkdown: messageUseMarkdown,
+                    messageStyler: messageStyler,
                     orientationHandler: orientationHandler,
                     mediaPickerSelectionParameters: mediaPickerSelectionParameters,
                     availableInputs: availableInputs,
@@ -331,7 +331,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
                showMessageMenuOnLongPress: showMessageMenuOnLongPress,
                tapAvatarClosure: tapAvatarClosure,
                paginationHandler: paginationHandler,
-               messageUseMarkdown: messageUseMarkdown,
+               messageStyler: messageStyler,
                showMessageTimeView: showMessageTimeView,
                messageFont: messageFont,
                sections: sections,
@@ -387,7 +387,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
                     inputFieldId: viewModel.inputFieldId,
                     style: .message,
                     availableInputs: availableInputs,
-                    messageUseMarkdown: messageUseMarkdown,
+                    messageStyler: messageStyler,
                     recorderSettings: recorderSettings,
                     localization: localization
                 )
@@ -418,7 +418,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
                 delegate: reactionDelegate,
                 didReact: reactionClosure(row.message)
             )) {
-                ChatMessageView(viewModel: viewModel, messageBuilder: messageBuilder, row: row, chatType: type, avatarSize: avatarSize, tapAvatarClosure: nil, messageUseMarkdown: messageUseMarkdown, isDisplayingMessageMenu: true, showMessageTimeView: showMessageTimeView, messageFont: messageFont)
+                ChatMessageView(viewModel: viewModel, messageBuilder: messageBuilder, row: row, chatType: type, avatarSize: avatarSize, tapAvatarClosure: nil, messageStyler: messageStyler, isDisplayingMessageMenu: true, showMessageTimeView: showMessageTimeView, messageFont: messageFont)
                     .onTapGesture {
                         hideMessageMenu()
                     }
@@ -601,7 +601,7 @@ public extension ChatView {
     
     func messageUseMarkdown(_ messageUseMarkdown: Bool) -> ChatView {
         var view = self
-        view.messageUseMarkdown = messageUseMarkdown
+        view.messageStyler = String.markdownStyler
         return view
     }
     

--- a/Sources/ExyteChat/ChatView/ChatView.swift
+++ b/Sources/ExyteChat/ChatView/ChatView.swift
@@ -600,8 +600,12 @@ public extension ChatView {
     }
     
     func messageUseMarkdown(_ messageUseMarkdown: Bool) -> ChatView {
+        return messageUseStyler(String.markdownStyler)
+    }
+
+    func messageUseStyler(_ styler: @escaping (String) -> AttributedString) -> ChatView {
         var view = self
-        view.messageStyler = String.markdownStyler
+        view.messageStyler = styler
         return view
     }
     

--- a/Sources/ExyteChat/ChatView/ChatView.swift
+++ b/Sources/ExyteChat/ChatView/ChatView.swift
@@ -315,28 +315,29 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
     
     @ViewBuilder
     var list: some View {
-        UIList(viewModel: viewModel,
-               inputViewModel: inputViewModel,
-               isScrolledToBottom: $isScrolledToBottom,
-               shouldScrollToTop: $shouldScrollToTop,
-               tableContentHeight: $tableContentHeight,
-               messageBuilder: messageBuilder,
-               mainHeaderBuilder: mainHeaderBuilder,
-               headerBuilder: headerBuilder,
-               inputView: inputView,
-               type: type,
-               showDateHeaders: showDateHeaders,
-               isScrollEnabled: isScrollEnabled,
-               avatarSize: avatarSize,
-               showMessageMenuOnLongPress: showMessageMenuOnLongPress,
-               tapAvatarClosure: tapAvatarClosure,
-               paginationHandler: paginationHandler,
-               messageStyler: messageStyler,
-               showMessageTimeView: showMessageTimeView,
-               messageFont: messageFont,
-               sections: sections,
-               ids: ids,
-               listSwipeActions: listSwipeActions
+        UIList(
+            viewModel: viewModel,
+            inputViewModel: inputViewModel,
+            isScrolledToBottom: $isScrolledToBottom,
+            shouldScrollToTop: $shouldScrollToTop,
+            tableContentHeight: $tableContentHeight,
+            messageBuilder: messageBuilder,
+            mainHeaderBuilder: mainHeaderBuilder,
+            headerBuilder: headerBuilder,
+            inputView: inputView,
+            type: type,
+            showDateHeaders: showDateHeaders,
+            isScrollEnabled: isScrollEnabled,
+            avatarSize: avatarSize,
+            showMessageMenuOnLongPress: showMessageMenuOnLongPress,
+            tapAvatarClosure: tapAvatarClosure,
+            paginationHandler: paginationHandler,
+            messageStyler: messageStyler,
+            showMessageTimeView: showMessageTimeView,
+            messageFont: messageFont,
+            sections: sections,
+            ids: ids,
+            listSwipeActions: listSwipeActions
         )
         .applyIf(!isScrollEnabled) {
             $0.frame(height: tableContentHeight)
@@ -417,12 +418,18 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
             reactionHandler: MessageMenu.ReactionConfig(
                 delegate: reactionDelegate,
                 didReact: reactionClosure(row.message)
-            )) {
-                ChatMessageView(viewModel: viewModel, messageBuilder: messageBuilder, row: row, chatType: type, avatarSize: avatarSize, tapAvatarClosure: nil, messageStyler: messageStyler, isDisplayingMessageMenu: true, showMessageTimeView: showMessageTimeView, messageFont: messageFont)
-                    .onTapGesture {
-                        hideMessageMenu()
-                    }
+            )
+        ) {
+            ChatMessageView(
+                viewModel: viewModel, messageBuilder: messageBuilder, row: row, chatType: type,
+                avatarSize: avatarSize, tapAvatarClosure: nil, messageStyler: messageStyler,
+                isDisplayingMessageMenu: true, showMessageTimeView: showMessageTimeView,
+                messageFont: messageFont
+            )
+            .onTapGesture {
+                hideMessageMenu()
             }
+        }
     }
     
     /// Determines the message menu alignment based on ChatType and message sender.

--- a/Sources/ExyteChat/ChatView/InputView/InputView.swift
+++ b/Sources/ExyteChat/ChatView/InputView/InputView.swift
@@ -90,7 +90,7 @@ struct InputView: View {
     var inputFieldId: UUID
     var style: InputViewStyle
     var availableInputs: [AvailableInputType]
-    var messageUseMarkdown: Bool
+    var messageStyler: (String) -> AttributedString
     var recorderSettings: RecorderSettings = RecorderSettings()
     var localization: ChatLocalization
     
@@ -332,12 +332,7 @@ struct InputView: View {
     
     @ViewBuilder
     func textView(_ text: String) -> some View {
-        if messageUseMarkdown,
-           let attributed = try? AttributedString(markdown: text) {
-            Text(attributed)
-        } else {
-            Text(text)
-        }
+        Text(text.styled(using: messageStyler))
     }
     
     var attachButton: some View {

--- a/Sources/ExyteChat/ChatView/MessageView/ChatMessageView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/ChatMessageView.swift
@@ -19,7 +19,7 @@ struct ChatMessageView<MessageContent: View>: View {
     let chatType: ChatType
     let avatarSize: CGFloat
     let tapAvatarClosure: ChatView.TapAvatarClosure?
-    let messageUseMarkdown: Bool
+    let messageStyler: (String) -> AttributedString
     let isDisplayingMessageMenu: Bool
     let showMessageTimeView: Bool
     let messageFont: UIFont
@@ -45,7 +45,7 @@ struct ChatMessageView<MessageContent: View>: View {
                     chatType: chatType,
                     avatarSize: avatarSize,
                     tapAvatarClosure: tapAvatarClosure,
-                    messageUseMarkdown: messageUseMarkdown,
+                    messageStyler: messageStyler,
                     isDisplayingMessageMenu: isDisplayingMessageMenu,
                     showMessageTimeView: showMessageTimeView,
                     font: messageFont)

--- a/Sources/ExyteChat/ChatView/MessageView/MessageTextView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageTextView.swift
@@ -37,7 +37,11 @@ struct MessageTextView: View {
 
 struct MessageTextView_Previews: PreviewProvider {
     static var previews: some View {
-        MessageTextView(text: "Look at [this website](https://example.org)", messageStyler: AttributedString.init, userType: .other)
-        MessageTextView(text: "Look at [this website](https://example.org)", messageStyler: String.markdownStyler, userType: .other)
+        MessageTextView(
+            text: "Look at [this website](https://example.org)",
+            messageStyler: AttributedString.init, userType: .other)
+        MessageTextView(
+            text: "Look at [this website](https://example.org)",
+            messageStyler: String.markdownStyler, userType: .other)
     }
 }

--- a/Sources/ExyteChat/ChatView/MessageView/MessageTextView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageTextView.swift
@@ -11,21 +11,19 @@ struct MessageTextView: View {
 
     @Environment(\.chatTheme) private var theme
 
-    let text: String?
+    let text: String
     let messageUseMarkdown: Bool
     let userType: UserType
 
     var styledText: AttributedString {
-        let textToStyle = text ?? ""
-
         var result =
             if messageUseMarkdown,
                 let attributed = try? AttributedString(
-                    markdown: textToStyle, options: String.markdownOptions)
+                    markdown: text, options: String.markdownOptions)
             {
                 attributed
             } else {
-                AttributedString(stringLiteral: textToStyle)
+                AttributedString(stringLiteral: text)
             }
 
         result.foregroundColor = theme.colors.messageText(userType)

--- a/Sources/ExyteChat/ChatView/MessageView/MessageTextView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageTextView.swift
@@ -12,20 +12,11 @@ struct MessageTextView: View {
     @Environment(\.chatTheme) private var theme
 
     let text: String
-    let messageUseMarkdown: Bool
+    let messageStyler: (String) -> AttributedString
     let userType: UserType
 
     var styledText: AttributedString {
-        var result =
-            if messageUseMarkdown,
-                let attributed = try? AttributedString(
-                    markdown: text, options: String.markdownOptions)
-            {
-                attributed
-            } else {
-                AttributedString(stringLiteral: text)
-            }
-
+        var result = text.styled(using: messageStyler)
         result.foregroundColor = theme.colors.messageText(userType)
 
         for (link, range) in result.runs[\.link] {
@@ -46,11 +37,7 @@ struct MessageTextView: View {
 
 struct MessageTextView_Previews: PreviewProvider {
     static var previews: some View {
-        MessageTextView(
-            text: "Look at [this website](https://example.org)", messageUseMarkdown: true,
-            userType: .other)
-        MessageTextView(
-            text: "Look at [this website](https://example.org)", messageUseMarkdown: false,
-            userType: .other)
+        MessageTextView(text: "Look at [this website](https://example.org)", messageStyler: AttributedString.init, userType: .other)
+        MessageTextView(text: "Look at [this website](https://example.org)", messageStyler: String.markdownStyler, userType: .other)
     }
 }

--- a/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
+++ b/Sources/ExyteChat/ChatView/MessageView/MessageView.swift
@@ -19,7 +19,7 @@ struct MessageView: View {
     let chatType: ChatType
     let avatarSize: CGFloat
     let tapAvatarClosure: ChatView.TapAvatarClosure?
-    let messageUseMarkdown: Bool
+    let messageStyler: (String) -> AttributedString
     let isDisplayingMessageMenu: Bool
     let showMessageTimeView: Bool
     var font: UIFont
@@ -60,9 +60,11 @@ struct MessageView: View {
         - textPaddings
 
         let maxWidth = message.attachments.isEmpty ? widthWithoutMedia : MessageView.widthWithMedia - textPaddings
-        let finalWidth = message.text.width(withConstrainedWidth: maxWidth, font: font, messageUseMarkdown: messageUseMarkdown)
-        let lastLineWidth = message.text.lastLineWidth(labelWidth: maxWidth, font: font, messageUseMarkdown: messageUseMarkdown)
-        let numberOfLines = message.text.numberOfLines(labelWidth: maxWidth, font: font, messageUseMarkdown: messageUseMarkdown)
+        let styledText = message.text.styled(using: messageStyler)
+
+        let finalWidth = styledText.width(withConstrainedWidth: maxWidth, font: font)
+        let lastLineWidth = styledText.lastLineWidth(labelWidth: maxWidth, font: font)
+        let numberOfLines = styledText.numberOfLines(labelWidth: maxWidth, font: font)
 
         if numberOfLines == 1, finalWidth + CGFloat(timeWidth) < maxWidth {
             return .hstack
@@ -178,7 +180,7 @@ struct MessageView: View {
 
             if !message.text.isEmpty {
                 MessageTextView(
-                    text: message.text, messageUseMarkdown: messageUseMarkdown,
+                    text: message.text, messageStyler: messageStyler,
                     userType: message.user.type
                 )
                 .padding(.horizontal, MessageView.horizontalTextPadding)
@@ -233,7 +235,7 @@ struct MessageView: View {
     @ViewBuilder
     func textWithTimeView(_ message: Message) -> some View {
         let messageView = MessageTextView(
-            text: message.text, messageUseMarkdown: messageUseMarkdown,
+            text: message.text, messageStyler: messageStyler,
             userType: message.user.type
         )
         .fixedSize(horizontal: false, vertical: true)
@@ -370,7 +372,7 @@ struct MessageView_Preview: PreviewProvider {
                 chatType: .conversation,
                 avatarSize: 32,
                 tapAvatarClosure: nil,
-                messageUseMarkdown: false,
+                messageStyler: AttributedString.init,
                 isDisplayingMessageMenu: false,
                 showMessageTimeView: true,
                 font: UIFontMetrics.default.scaledFont(for: UIFont.systemFont(ofSize: 15))

--- a/Sources/ExyteChat/ChatView/UIList.swift
+++ b/Sources/ExyteChat/ChatView/UIList.swift
@@ -364,7 +364,16 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
     // MARK: - Coordinator
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(viewModel: viewModel, inputViewModel: inputViewModel, isScrolledToBottom: $isScrolledToBottom, isScrolledToTop: $isScrolledToTop, messageBuilder: messageBuilder, mainHeaderBuilder: mainHeaderBuilder, headerBuilder: headerBuilder, type: type, showDateHeaders: showDateHeaders, avatarSize: avatarSize, showMessageMenuOnLongPress: showMessageMenuOnLongPress, tapAvatarClosure: tapAvatarClosure, paginationHandler: paginationHandler, messageStyler: messageStyler, showMessageTimeView: showMessageTimeView, messageFont: messageFont, sections: sections, ids: ids, mainBackgroundColor: theme.colors.mainBG, listSwipeActions: listSwipeActions)
+        Coordinator(
+            viewModel: viewModel, inputViewModel: inputViewModel,
+            isScrolledToBottom: $isScrolledToBottom, isScrolledToTop: $isScrolledToTop,
+            messageBuilder: messageBuilder, mainHeaderBuilder: mainHeaderBuilder,
+            headerBuilder: headerBuilder, type: type, showDateHeaders: showDateHeaders,
+            avatarSize: avatarSize, showMessageMenuOnLongPress: showMessageMenuOnLongPress,
+            tapAvatarClosure: tapAvatarClosure, paginationHandler: paginationHandler,
+            messageStyler: messageStyler, showMessageTimeView: showMessageTimeView,
+            messageFont: messageFont, sections: sections, ids: ids,
+            mainBackgroundColor: theme.colors.mainBG, listSwipeActions: listSwipeActions)
     }
 
     class Coordinator: NSObject, UITableViewDataSource, UITableViewDelegate {
@@ -399,7 +408,18 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
         let mainBackgroundColor: Color
         let listSwipeActions: ListSwipeActions
 
-        init(viewModel: ChatViewModel, inputViewModel: InputViewModel, isScrolledToBottom: Binding<Bool>, isScrolledToTop: Binding<Bool>, messageBuilder: MessageBuilderClosure?, mainHeaderBuilder: (()->AnyView)?, headerBuilder: ((Date)->AnyView)?, type: ChatType, showDateHeaders: Bool, avatarSize: CGFloat, showMessageMenuOnLongPress: Bool, tapAvatarClosure: ChatView.TapAvatarClosure?, paginationHandler: PaginationHandler?, messageStyler: @escaping (String) -> AttributedString, showMessageTimeView: Bool, messageFont: UIFont, sections: [MessagesSection], ids: [String], mainBackgroundColor: Color, paginationTargetIndexPath: IndexPath? = nil, listSwipeActions: ListSwipeActions) {
+        init(
+            viewModel: ChatViewModel, inputViewModel: InputViewModel,
+            isScrolledToBottom: Binding<Bool>, isScrolledToTop: Binding<Bool>,
+            messageBuilder: MessageBuilderClosure?, mainHeaderBuilder: (() -> AnyView)?,
+            headerBuilder: ((Date) -> AnyView)?, type: ChatType, showDateHeaders: Bool,
+            avatarSize: CGFloat, showMessageMenuOnLongPress: Bool,
+            tapAvatarClosure: ChatView.TapAvatarClosure?, paginationHandler: PaginationHandler?,
+            messageStyler: @escaping (String) -> AttributedString, showMessageTimeView: Bool,
+            messageFont: UIFont, sections: [MessagesSection], ids: [String],
+            mainBackgroundColor: Color, paginationTargetIndexPath: IndexPath? = nil,
+            listSwipeActions: ListSwipeActions
+        ) {
             self.viewModel = viewModel
             self.inputViewModel = inputViewModel
             self._isScrolledToBottom = isScrolledToBottom
@@ -542,19 +562,24 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
 
             let row = sections[indexPath.section].rows[indexPath.row]
             tableViewCell.contentConfiguration = UIHostingConfiguration {
-                ChatMessageView(viewModel: viewModel, messageBuilder: messageBuilder, row: row, chatType: type, avatarSize: avatarSize, tapAvatarClosure: tapAvatarClosure, messageStyler: messageStyler, isDisplayingMessageMenu: false, showMessageTimeView: showMessageTimeView, messageFont: messageFont)
-                    .transition(.scale)
-                    .background(MessageMenuPreferenceViewSetter(id: row.id))
-                    .rotationEffect(Angle(degrees: (type == .conversation ? 180 : 0)))
-                    .onTapGesture { }
-                    .applyIf(showMessageMenuOnLongPress) {
-                        $0.onLongPressGesture {
-                            // Trigger haptic feedback
-                            self.viewModel.impactGenerator.impactOccurred()
-                            // Launch the message menu
-                            self.viewModel.messageMenuRow = row
-                        }
+                ChatMessageView(
+                    viewModel: viewModel, messageBuilder: messageBuilder, row: row, chatType: type,
+                    avatarSize: avatarSize, tapAvatarClosure: tapAvatarClosure,
+                    messageStyler: messageStyler, isDisplayingMessageMenu: false,
+                    showMessageTimeView: showMessageTimeView, messageFont: messageFont
+                )
+                .transition(.scale)
+                .background(MessageMenuPreferenceViewSetter(id: row.id))
+                .rotationEffect(Angle(degrees: (type == .conversation ? 180 : 0)))
+                .onTapGesture {}
+                .applyIf(showMessageMenuOnLongPress) {
+                    $0.onLongPressGesture {
+                        // Trigger haptic feedback
+                        self.viewModel.impactGenerator.impactOccurred()
+                        // Launch the message menu
+                        self.viewModel.messageMenuRow = row
                     }
+                }
             }
             .minSize(width: 0, height: 0)
             .margins(.all, 0)

--- a/Sources/ExyteChat/ChatView/UIList.swift
+++ b/Sources/ExyteChat/ChatView/UIList.swift
@@ -36,7 +36,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
     let showMessageMenuOnLongPress: Bool
     let tapAvatarClosure: ChatView.TapAvatarClosure?
     let paginationHandler: PaginationHandler?
-    let messageUseMarkdown: Bool
+    let messageStyler: (String) -> AttributedString
     let showMessageTimeView: Bool
     let messageFont: UIFont
     let sections: [MessagesSection]
@@ -364,7 +364,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
     // MARK: - Coordinator
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(viewModel: viewModel, inputViewModel: inputViewModel, isScrolledToBottom: $isScrolledToBottom, isScrolledToTop: $isScrolledToTop, messageBuilder: messageBuilder, mainHeaderBuilder: mainHeaderBuilder, headerBuilder: headerBuilder, type: type, showDateHeaders: showDateHeaders, avatarSize: avatarSize, showMessageMenuOnLongPress: showMessageMenuOnLongPress, tapAvatarClosure: tapAvatarClosure, paginationHandler: paginationHandler, messageUseMarkdown: messageUseMarkdown, showMessageTimeView: showMessageTimeView, messageFont: messageFont, sections: sections, ids: ids, mainBackgroundColor: theme.colors.mainBG, listSwipeActions: listSwipeActions)
+        Coordinator(viewModel: viewModel, inputViewModel: inputViewModel, isScrolledToBottom: $isScrolledToBottom, isScrolledToTop: $isScrolledToTop, messageBuilder: messageBuilder, mainHeaderBuilder: mainHeaderBuilder, headerBuilder: headerBuilder, type: type, showDateHeaders: showDateHeaders, avatarSize: avatarSize, showMessageMenuOnLongPress: showMessageMenuOnLongPress, tapAvatarClosure: tapAvatarClosure, paginationHandler: paginationHandler, messageStyler: messageStyler, showMessageTimeView: showMessageTimeView, messageFont: messageFont, sections: sections, ids: ids, mainBackgroundColor: theme.colors.mainBG, listSwipeActions: listSwipeActions)
     }
 
     class Coordinator: NSObject, UITableViewDataSource, UITableViewDelegate {
@@ -385,7 +385,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
         let showMessageMenuOnLongPress: Bool
         let tapAvatarClosure: ChatView.TapAvatarClosure?
         let paginationHandler: PaginationHandler?
-        let messageUseMarkdown: Bool
+        let messageStyler: (String) -> AttributedString
         let showMessageTimeView: Bool
         let messageFont: UIFont
         var sections: [MessagesSection] {
@@ -399,7 +399,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
         let mainBackgroundColor: Color
         let listSwipeActions: ListSwipeActions
 
-        init(viewModel: ChatViewModel, inputViewModel: InputViewModel, isScrolledToBottom: Binding<Bool>, isScrolledToTop: Binding<Bool>, messageBuilder: MessageBuilderClosure?, mainHeaderBuilder: (()->AnyView)?, headerBuilder: ((Date)->AnyView)?, type: ChatType, showDateHeaders: Bool, avatarSize: CGFloat, showMessageMenuOnLongPress: Bool, tapAvatarClosure: ChatView.TapAvatarClosure?, paginationHandler: PaginationHandler?, messageUseMarkdown: Bool, showMessageTimeView: Bool, messageFont: UIFont, sections: [MessagesSection], ids: [String], mainBackgroundColor: Color, paginationTargetIndexPath: IndexPath? = nil, listSwipeActions: ListSwipeActions) {
+        init(viewModel: ChatViewModel, inputViewModel: InputViewModel, isScrolledToBottom: Binding<Bool>, isScrolledToTop: Binding<Bool>, messageBuilder: MessageBuilderClosure?, mainHeaderBuilder: (()->AnyView)?, headerBuilder: ((Date)->AnyView)?, type: ChatType, showDateHeaders: Bool, avatarSize: CGFloat, showMessageMenuOnLongPress: Bool, tapAvatarClosure: ChatView.TapAvatarClosure?, paginationHandler: PaginationHandler?, messageStyler: @escaping (String) -> AttributedString, showMessageTimeView: Bool, messageFont: UIFont, sections: [MessagesSection], ids: [String], mainBackgroundColor: Color, paginationTargetIndexPath: IndexPath? = nil, listSwipeActions: ListSwipeActions) {
             self.viewModel = viewModel
             self.inputViewModel = inputViewModel
             self._isScrolledToBottom = isScrolledToBottom
@@ -413,7 +413,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
             self.showMessageMenuOnLongPress = showMessageMenuOnLongPress
             self.tapAvatarClosure = tapAvatarClosure
             self.paginationHandler = paginationHandler
-            self.messageUseMarkdown = messageUseMarkdown
+            self.messageStyler = messageStyler
             self.showMessageTimeView = showMessageTimeView
             self.messageFont = messageFont
             self.sections = sections
@@ -542,7 +542,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
 
             let row = sections[indexPath.section].rows[indexPath.row]
             tableViewCell.contentConfiguration = UIHostingConfiguration {
-                ChatMessageView(viewModel: viewModel, messageBuilder: messageBuilder, row: row, chatType: type, avatarSize: avatarSize, tapAvatarClosure: tapAvatarClosure, messageUseMarkdown: messageUseMarkdown, isDisplayingMessageMenu: false, showMessageTimeView: showMessageTimeView, messageFont: messageFont)
+                ChatMessageView(viewModel: viewModel, messageBuilder: messageBuilder, row: row, chatType: type, avatarSize: avatarSize, tapAvatarClosure: tapAvatarClosure, messageStyler: messageStyler, isDisplayingMessageMenu: false, showMessageTimeView: showMessageTimeView, messageFont: messageFont)
                     .transition(.scale)
                     .background(MessageMenuPreferenceViewSetter(id: row.id))
                     .rotationEffect(Angle(degrees: (type == .conversation ? 180 : 0)))

--- a/Sources/ExyteChat/Extensions/AttributedString+Size.swift
+++ b/Sources/ExyteChat/Extensions/AttributedString+Size.swift
@@ -5,31 +5,24 @@
 import SwiftUI
 import UIKit
 
-extension String {
+extension AttributedString {
 
-    static func localizedFormat(key: String, _ args: CVarArg...) -> String {
-        let localizedString = NSLocalizedString(key, comment: "")
-        return String(format: localizedString, arguments: args)
-    }
-
-    func width(withConstrainedWidth width: CGFloat, font: UIFont, messageUseMarkdown: Bool) -> CGFloat {
+    func width(withConstrainedWidth width: CGFloat, font: UIFont) -> CGFloat {
         let constraintRect = CGSize(width: width, height: .greatestFiniteMagnitude)
-        let boundingBox = toAttrString(font: font, messageUseMarkdown: messageUseMarkdown).boundingRect(with: constraintRect,
-                                                      options: .usesLineFragmentOrigin,
-                                                      context: nil)
+        let boundingBox = toAttrString(font: font).boundingRect(with: constraintRect, options: .usesLineFragmentOrigin, context: nil)
 
         return ceil(boundingBox.width)
     }
 
-    func toAttrString(font: UIFont, messageUseMarkdown: Bool) -> NSAttributedString {
-        var str = messageUseMarkdown ? (try? AttributedString(markdown: self, options: String.markdownOptions)) ?? AttributedString(self) : AttributedString(self)
+    func toAttrString(font: UIFont) -> NSAttributedString {
+        var str = self
         str.setAttributes(AttributeContainer([.font: font]))
         return NSAttributedString(str)
     }
 
-    public func lastLineWidth(labelWidth: CGFloat, font: UIFont, messageUseMarkdown: Bool) -> CGFloat {
+    public func lastLineWidth(labelWidth: CGFloat, font: UIFont) -> CGFloat {
         // Create instances of NSLayoutManager, NSTextContainer and NSTextStorage
-        let attrString = toAttrString(font: font, messageUseMarkdown: messageUseMarkdown)
+        let attrString = toAttrString(font: font)
         let availableSize = CGSize(width: labelWidth, height: .infinity)
         let layoutManager = NSLayoutManager()
         let textContainer = NSTextContainer(size: availableSize)
@@ -52,11 +45,12 @@ extension String {
         return lastLineFragmentRect.maxX
     }
 
-    func numberOfLines(labelWidth: CGFloat, font: UIFont, messageUseMarkdown: Bool) -> Int {
-        let attrString = toAttrString(font: font, messageUseMarkdown: messageUseMarkdown)
+    func numberOfLines(labelWidth: CGFloat, font: UIFont) -> Int {
+        let attrString = toAttrString(font: font)
         let availableSize = CGSize(width: labelWidth, height: .infinity)
         let textSize = attrString.boundingRect(with: availableSize, options: .usesLineFragmentOrigin, context: nil)
         let lineHeight = font.lineHeight
         return Int(ceil(textSize.height/lineHeight))
     }
+
 }

--- a/Sources/ExyteChat/Extensions/String+Size.swift
+++ b/Sources/ExyteChat/Extensions/String+Size.swift
@@ -12,13 +12,6 @@ extension String {
         return String(format: localizedString, arguments: args)
     }
 
-    static var markdownOptions = AttributedString.MarkdownParsingOptions(
-        allowsExtendedAttributes: false,
-        interpretedSyntax: .inlineOnlyPreservingWhitespace,
-        failurePolicy: .returnPartiallyParsedIfPossible,
-        languageCode: nil
-    )
-
     func width(withConstrainedWidth width: CGFloat, font: UIFont, messageUseMarkdown: Bool) -> CGFloat {
         let constraintRect = CGSize(width: width, height: .greatestFiniteMagnitude)
         let boundingBox = toAttrString(font: font, messageUseMarkdown: messageUseMarkdown).boundingRect(with: constraintRect,

--- a/Sources/ExyteChat/Extensions/String+Style.swift
+++ b/Sources/ExyteChat/Extensions/String+Style.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension String {
 
-    public static var markdownOptions = AttributedString.MarkdownParsingOptions(
+    private static var markdownOptions = AttributedString.MarkdownParsingOptions(
         allowsExtendedAttributes: false,
         interpretedSyntax: .inlineOnlyPreservingWhitespace,
         failurePolicy: .returnPartiallyParsedIfPossible,

--- a/Sources/ExyteChat/Extensions/String+Style.swift
+++ b/Sources/ExyteChat/Extensions/String+Style.swift
@@ -1,0 +1,31 @@
+//
+//  String+Style.swift
+//  Chat
+//
+//  Created by Matthew Fennell on 01/03/2025.
+//
+
+import Foundation
+
+extension String {
+
+    public static var markdownOptions = AttributedString.MarkdownParsingOptions(
+        allowsExtendedAttributes: false,
+        interpretedSyntax: .inlineOnlyPreservingWhitespace,
+        failurePolicy: .returnPartiallyParsedIfPossible,
+        languageCode: nil
+    )
+
+    public static func markdownStyler(text: String) -> AttributedString {
+        if let attributed = try? AttributedString(markdown: text, options: String.markdownOptions) {
+            attributed
+        } else {
+            AttributedString(stringLiteral: text)
+        }
+    }
+
+    public func styled(using styler: (String) -> AttributedString) -> AttributedString {
+        styler(self)
+    }
+
+}


### PR DESCRIPTION
This PR is the first part of #74 (I'm also working on link previews, in a separate PR).

[I initially wrote](https://github.com/exyte/Chat/issues/74#issuecomment-2675879705):

> One approach could be to change Message.text from a String to an AttributedString. This would let consumers pass links in a general way, also giving arbitrary styling for free.

This PR uses a (hopefully) better approach: users still pass a `String`, but also pass a `messageStyler` which converts from `String` to `AttributedString`.

This lets us keep a clear separation between the model (`String`) and view (`AttributedString`), and makes the logic when editing a message a lot simpler (just take the message's `String` instead of trying to convert it back from an `AttributedString`).

To use links, you can either use the markdown styler (as before), or pass your own styler with `messageUseStyler` that searches for links and gives them the link attribute. Of course, you can also add other attributes like bold, italic, underline, etc.

To test, I checked that the `ChatExample` is still working:

![link](https://github.com/user-attachments/assets/67da9c40-dc1e-494d-9401-676bed4ef4a1)

Hope this is useful. Please let me know if you have any suggestions or improvements. Have a good day!