### PR TITLE
Remove invalid ExyteChat package depdendencies in example apps

### DIFF
--- a/ChatExample/ChatExample.xcodeproj/project.pbxproj
+++ b/ChatExample/ChatExample.xcodeproj/project.pbxproj
@@ -22,11 +22,10 @@
 		13E17B6F2869E983004DF140 /* MockChatData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E17B6E2869E983004DF140 /* MockChatData.swift */; };
 		13F1C0EF286AC86200D25D8A /* ChatExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13F1C0EE286AC86200D25D8A /* ChatExampleView.swift */; };
 		13F1C0F2286ADD8900D25D8A /* MockAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13F1C0F1286ADD8900D25D8A /* MockAttachment.swift */; };
+		34D099962D930F350014B72C /* ExyteChat in Frameworks */ = {isa = PBXBuildFile; productRef = 34D099952D930F350014B72C /* ExyteChat */; };
 		5B0636D72C2E9F6100E54AEE /* CommentsExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0636D52C2E9F6100E54AEE /* CommentsExampleView.swift */; };
 		5B0636D82C2E9F6100E54AEE /* CommentsExampleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0636D62C2E9F6100E54AEE /* CommentsExampleViewModel.swift */; };
 		5B0636DB2C2EA21900E54AEE /* Sequence+asyncMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0636DA2C2EA21900E54AEE /* Sequence+asyncMap.swift */; };
-		5B4D04FE2D92FA36005262A1 /* ExyteChat in Frameworks */ = {isa = PBXBuildFile; productRef = 5B4D04FD2D92FA36005262A1 /* ExyteChat */; };
-		5B4DBAA52D92E2560067A006 /* ExyteChat in Frameworks */ = {isa = PBXBuildFile; productRef = 5B4DBAA42D92E2560067A006 /* ExyteChat */; };
 		5B6D3A732987D85A00765148 /* Color+hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6D3A722987D85A00765148 /* Color+hex.swift */; };
 /* End PBXBuildFile section */
 
@@ -72,8 +71,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5B4D04FE2D92FA36005262A1 /* ExyteChat in Frameworks */,
-				5B4DBAA52D92E2560067A006 /* ExyteChat in Frameworks */,
+				34D099962D930F350014B72C /* ExyteChat in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -205,8 +203,7 @@
 			);
 			name = ChatExample;
 			packageProductDependencies = (
-				5B4DBAA42D92E2560067A006 /* ExyteChat */,
-				5B4D04FD2D92FA36005262A1 /* ExyteChat */,
+				34D099952D930F350014B72C /* ExyteChat */,
 			);
 			productName = ChatExample;
 			productReference = 135549302864620900C9459A /* ChatExample.app */;
@@ -237,7 +234,7 @@
 			);
 			mainGroup = 135549272864620900C9459A;
 			packageReferences = (
-				5B4D04FC2D92FA36005262A1 /* XCLocalSwiftPackageReference "../../Chat" */,
+				34D099942D930F340014B72C /* XCLocalSwiftPackageReference "../../ExyteChat" */,
 			);
 			productRefGroup = 135549312864620900C9459A /* Products */;
 			projectDirPath = "";
@@ -507,18 +504,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		5B4D04FC2D92FA36005262A1 /* XCLocalSwiftPackageReference "../../Chat" */ = {
+		34D099942D930F340014B72C /* XCLocalSwiftPackageReference "../../ExyteChat" */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = ../../Chat;
+			relativePath = ../../ExyteChat;
 		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		5B4D04FD2D92FA36005262A1 /* ExyteChat */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = ExyteChat;
-		};
-		5B4DBAA42D92E2560067A006 /* ExyteChat */ = {
+		34D099952D930F350014B72C /* ExyteChat */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ExyteChat;
 		};

--- a/ChatFirestoreExample/ChatFirestoreExample.xcodeproj/project.pbxproj
+++ b/ChatFirestoreExample/ChatFirestoreExample.xcodeproj/project.pbxproj
@@ -24,7 +24,6 @@
 		5B5748372A3707860033C808 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5B5748362A3707860033C808 /* Preview Assets.xcassets */; };
 		5B5748452A3714AE0033C808 /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5748442A3714AE0033C808 /* AuthViewModel.swift */; };
 		5B5748472A3714BA0033C808 /* AuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5748462A3714BA0033C808 /* AuthView.swift */; };
-		5B6C8D7F2D92B6A500E8714B /* ExyteChat in Frameworks */ = {isa = PBXBuildFile; productRef = 5B6C8D7E2D92B6A500E8714B /* ExyteChat */; };
 		5B73CB432A5D465C007D80B0 /* SearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B73CB422A5D465C007D80B0 /* SearchField.swift */; };
 		5B73CB452A5D4A77007D80B0 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B73CB442A5D4A77007D80B0 /* CustomTextField.swift */; };
 		5B897B3C2A42C347005274DE /* CachedAsyncImage in Frameworks */ = {isa = PBXBuildFile; productRef = 5B897B3B2A42C347005274DE /* CachedAsyncImage */; };
@@ -99,7 +98,6 @@
 				5B897B3C2A42C347005274DE /* CachedAsyncImage in Frameworks */,
 				5B9920EE2A4050A300995901 /* FirebaseStorage in Frameworks */,
 				5B4D05012D92FA73005262A1 /* ExyteChat in Frameworks */,
-				5B6C8D7F2D92B6A500E8714B /* ExyteChat in Frameworks */,
 				5B9920EA2A4050A300995901 /* FirebaseFirestore in Frameworks */,
 				5B9920EC2A4050A300995901 /* FirebaseFirestoreSwift in Frameworks */,
 			);
@@ -263,7 +261,6 @@
 				5B9920EB2A4050A300995901 /* FirebaseFirestoreSwift */,
 				5B9920ED2A4050A300995901 /* FirebaseStorage */,
 				5B897B3B2A42C347005274DE /* CachedAsyncImage */,
-				5B6C8D7E2D92B6A500E8714B /* ExyteChat */,
 				5B4D05002D92FA73005262A1 /* ExyteChat */,
 			);
 			productName = ChatFirestoreExample;
@@ -297,7 +294,7 @@
 			packageReferences = (
 				5B9920E82A4050A200995901 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				5B897B3A2A42C347005274DE /* XCRemoteSwiftPackageReference "swiftui-cached-async-image" */,
-				5B4D04FF2D92FA73005262A1 /* XCLocalSwiftPackageReference "../../Chat" */,
+				5B4D04FF2D92FA73005262A1 /* XCLocalSwiftPackageReference "../../ExyteChat" */,
 			);
 			productRefGroup = 5B57482D2A3707850033C808 /* Products */;
 			projectDirPath = "";
@@ -585,9 +582,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		5B4D04FF2D92FA73005262A1 /* XCLocalSwiftPackageReference "../../Chat" */ = {
+		5B4D04FF2D92FA73005262A1 /* XCLocalSwiftPackageReference "../../ExyteChat" */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = ../../Chat;
+			relativePath = ../../ExyteChat;
 		};
 /* End XCLocalSwiftPackageReference section */
 
@@ -612,10 +609,6 @@
 
 /* Begin XCSwiftPackageProductDependency section */
 		5B4D05002D92FA73005262A1 /* ExyteChat */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = ExyteChat;
-		};
-		5B6C8D7E2D92B6A500E8714B /* ExyteChat */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ExyteChat;
 		};


### PR DESCRIPTION
The example apps have some duplicate references to `ExyteChat`, some of them containing the old path `../Chat`.

This causes them to fail to build with "Missing package product 'ExyteChat'".

This PR removes these duplicate / incorrect entries so they can build again.