### PR TITLE
Fix Chat Example

### DIFF
--- a/ChatExample/ChatExample/ContentView.swift
+++ b/ChatExample/ChatExample/ContentView.swift
@@ -3,19 +3,20 @@
 //
 
 import SwiftUI
+import ExyteChat
 import ExyteMediaPicker
 
 struct ContentView: View {
     
-    @State private var isAccent: Bool = true
+    @State private var theme: ExampleThemeState = .accent
     @State private var color = Color(.exampleBlue)
-
+    
     var body: some View {
         NavigationView {
             List {
                 Section {
                     NavigationLink("Active chat example") {
-                        if !isAccent, #available(iOS 18.0, *) {
+                        if !theme.isAccent, #available(iOS 18.0, *) {
                             ChatExampleView(
                                 viewModel: ChatExampleViewModel(interactor: MockChatInteractor(isActive: true)),
                                 title: "Active chat example"
@@ -26,29 +27,24 @@ struct ContentView: View {
                                 viewModel: ChatExampleViewModel(interactor: MockChatInteractor(isActive: true)),
                                 title: "Active chat example"
                             )
-                            .chatTheme(accentColor: color)
+                            .chatTheme(
+                                accentColor: color,
+                                images: theme.images
+                            )
                         }
                     }
                     
                     NavigationLink("Simple chat example") {
-                        if !isAccent, #available(iOS 18.0, *) {
-                            ChatExampleView(title: "Simple example")
+                        if !theme.isAccent, #available(iOS 18.0, *) {
+                            ChatExampleView(title: "Simple chat example")
                                 .chatTheme(themeColor: color)
                         } else {
-                            ChatExampleView(title: "Simple example")
-                                .chatTheme(accentColor: color)
-                        }
-                    }
-                    
-                    NavigationLink("Chat with Image Background") {
-                        ChatExampleView(title: "Background Image")
-                            .chatTheme(
-                                accentColor: color,
-                                images: .init(
-                                    backgroundLight: Image("chatBackgroundLight"),
-                                    backgroundDark: Image("chatBackgroundDark")
+                            ChatExampleView(title: "Simple chat example")
+                                .chatTheme(
+                                    accentColor: color,
+                                    images: theme.images
                                 )
-                            )
+                        }
                     }
 
                     NavigationLink("Simple comments example") {
@@ -78,16 +74,11 @@ struct ContentView: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     HStack {
-                        if #available(iOS 18.0, *) {
-                            Button(isAccent ? "Accent" : "Themed") {
-                                isAccent.toggle()
-                            }
-                            ColorPicker("", selection: $color)
-                        } else {
-                            ColorPicker("Accent", selection: $color)
+                        Button(theme.title) {
+                            theme = theme.next()
                         }
+                        ColorPicker("", selection: $color)
                     }
-                    
                 }
             }
         }

--- a/ChatExample/ChatExample/ContentView.swift
+++ b/ChatExample/ChatExample/ContentView.swift
@@ -94,3 +94,49 @@ struct ContentView: View {
         .navigationViewStyle(.stack)
     }
 }
+
+/// An enum that lets us iterate through the different ChatTheme styles
+enum ExampleThemeState: String {
+    case accent
+    case image
+    
+    @available(iOS 18, *)
+    case themed
+    
+    var title:String {
+        self.rawValue.capitalized
+    }
+    
+    func next() -> ExampleThemeState {
+        switch self {
+        case .accent:
+            if #available(iOS 18.0, *) {
+                return .themed
+            } else {
+                return .image
+            }
+        case .themed:
+            return .image
+        case .image:
+            return .accent
+        }
+    }
+    
+    var images: ChatTheme.Images {
+        switch self {
+        case .accent, .themed: return .init()
+        case .image:
+            return .init(
+                backgroundLight: Image("chatBackgroundLight"),
+                backgroundDark: Image("chatBackgroundDark")
+            )
+        }
+    }
+    
+    var isAccent: Bool {
+        if #available(iOS 18.0, *) {
+            return self != .themed
+        }
+        return true
+    }
+}

--- a/ChatExample/ChatExample/ContentView.swift
+++ b/ChatExample/ChatExample/ContentView.swift
@@ -39,6 +39,17 @@ struct ContentView: View {
                                 .chatTheme(accentColor: color)
                         }
                     }
+                    
+                    NavigationLink("Chat with Image Background") {
+                        ChatExampleView(title: "Background Image")
+                            .chatTheme(
+                                accentColor: color,
+                                images: .init(
+                                    backgroundLight: Image("chatBackgroundLight"),
+                                    backgroundDark: Image("chatBackgroundDark")
+                                )
+                            )
+                    }
 
                     NavigationLink("Simple comments example") {
                         CommentsExampleView()

--- a/ChatExample/ChatExample/Screens/ChatExampleView.swift
+++ b/ChatExample/ChatExample/Screens/ChatExampleView.swift
@@ -45,13 +45,6 @@ struct ChatExampleView: View {
                 }
             }
         ])
-        .chatTheme(
-            colors: .init(),
-            images: .init(
-                backgroundLight: Image("chatBackgroundLight"),
-                backgroundDark: Image("chatBackgroundDark")
-            )
-        )
         .navigationBarBackButtonHidden()
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {

--- a/Sources/ExyteChat/Theme/ChatTheme+Auto.swift
+++ b/Sources/ExyteChat/Theme/ChatTheme+Auto.swift
@@ -13,8 +13,8 @@ extension View {
     /// Creates and applies a `ChatTheme` to your `ChatView` based around the provided `accentColor`
     /// - Parameters:
     ///   - color: The main accent color of your `ChatView`
-    public func chatTheme(accentColor: Color) -> some View {
-        self.chatTheme(ChatTheme(accentColor: accentColor))
+    public func chatTheme(accentColor: Color, images: ChatTheme.Images = .init()) -> some View {
+        self.chatTheme(ChatTheme(accentColor: accentColor, images: images))
     }
 }
 

--- a/Sources/ExyteChat/Theme/ChatTheme.swift
+++ b/Sources/ExyteChat/Theme/ChatTheme.swift
@@ -55,14 +55,15 @@ public struct ChatTheme {
         }
     }
     
-    internal init(accentColor: Color) {
+    internal init(accentColor: Color, images: ChatTheme.Images) {
         self.init(
             colors: .init(
                 mainTint: accentColor,
                 messageMyBG: accentColor,
                 messageMyTimeText: Color.white.opacity(0.5),
                 sendButtonBackground: accentColor
-            )
+            ),
+            images: images
         )
     }
     


### PR DESCRIPTION
### What: 
- Fixes the original 'Simple Chat Example'
- Adds a new section in the chat example app that showcases background images and honors the current accent color.

### Why:
- PR #157 broke the ChatExample app by overwriting the chat's theme in the `ChatExampleView.swift` as opposed to setting it the `ContentView.swift` file.