### PR TITLE
Fix Message Menu Items

### DIFF
--- a/Sources/ExyteChat/Views/MessageView/MessageMenu/MessageMenu.swift
+++ b/Sources/ExyteChat/Views/MessageView/MessageMenu/MessageMenu.swift
@@ -507,7 +507,7 @@ struct MessageMenu<MainButton: View, ActionEnum: MessageMenuAction>: View {
     
     @ViewBuilder
     func menuView() -> some View {
-        let buttons = ActionEnum.allCases.enumerated().map { MenuButton(id: $0, action: $1) }
+        let buttons = ActionEnum.menuItems(for: message).enumerated().map { MenuButton(id: $0, action: $1) }
         HStack {
             if alignment == .right { Spacer() }
             


### PR DESCRIPTION
### What:
- Only populate the message menu with items for the current message, not `allCases`

### Fixes:
- #154 