### PR TITLE
Configurably hide link previews for specific URLs

### DIFF
--- a/Sources/ExyteChat/Views/ChatView.swift
+++ b/Sources/ExyteChat/Views/ChatView.swift
@@ -112,6 +112,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
     var isScrollEnabled: Bool = true
     var avatarSize: CGFloat = 32
     var messageStyler: (String) -> AttributedString = AttributedString.init
+    var shouldShowLinkPreview: (URL) -> Bool = { _ in true }
     var showMessageMenuOnLongPress: Bool = true
     var messageMenuAnimationDuration: Double = 0.3
     var showNetworkConnectionProblem: Bool = false
@@ -333,6 +334,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
             tapAvatarClosure: tapAvatarClosure,
             paginationHandler: paginationHandler,
             messageStyler: messageStyler,
+            shouldShowLinkPreview: shouldShowLinkPreview,
             showMessageTimeView: showMessageTimeView,
             messageLinkPreviewLimit: messageLinkPreviewLimit,
             messageFont: messageFont,
@@ -428,6 +430,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
             ChatMessageView(
                 viewModel: viewModel, messageBuilder: messageBuilder, row: row, chatType: type,
                 avatarSize: avatarSize, tapAvatarClosure: nil, messageStyler: messageStyler,
+                shouldShowLinkPreview: shouldShowLinkPreview,
                 isDisplayingMessageMenu: true, showMessageTimeView: showMessageTimeView,
                 messageLinkPreviewLimit: messageLinkPreviewLimit, messageFont: messageFont
             )
@@ -653,6 +656,12 @@ public extension ChatView {
         return view
     }
     
+    func shouldShowLinkPreview(_ shouldShowLinkPreview: @escaping (URL) -> Bool) -> ChatView {
+        var view = self
+        view.shouldShowLinkPreview = shouldShowLinkPreview
+        return view
+    }
+
     func showMessageTimeView(_ isShow: Bool) -> ChatView {
         var view = self
         view.showMessageTimeView = isShow

--- a/Sources/ExyteChat/Views/MessageView/ChatMessageView.swift
+++ b/Sources/ExyteChat/Views/MessageView/ChatMessageView.swift
@@ -20,6 +20,7 @@ struct ChatMessageView<MessageContent: View>: View {
     let avatarSize: CGFloat
     let tapAvatarClosure: ChatView.TapAvatarClosure?
     let messageStyler: (String) -> AttributedString
+    let shouldShowLinkPreview: (URL) -> Bool
     let isDisplayingMessageMenu: Bool
     let showMessageTimeView: Bool
     let messageLinkPreviewLimit: Int
@@ -47,6 +48,7 @@ struct ChatMessageView<MessageContent: View>: View {
                     avatarSize: avatarSize,
                     tapAvatarClosure: tapAvatarClosure,
                     messageStyler: messageStyler,
+                    shouldShowLinkPreview: shouldShowLinkPreview,
                     isDisplayingMessageMenu: isDisplayingMessageMenu,
                     showMessageTimeView: showMessageTimeView,
                     messageLinkPreviewLimit: messageLinkPreviewLimit,

--- a/Sources/ExyteChat/Views/MessageView/MessageTextView.swift
+++ b/Sources/ExyteChat/Views/MessageView/MessageTextView.swift
@@ -21,6 +21,7 @@ struct MessageTextView: View {
     let text: String
     let messageStyler: (String) -> AttributedString
     let userType: UserType
+    let shouldShowLinkPreview: (URL) -> Bool
     let messageLinkPreviewLimit: Int
 
     var styledText: AttributedString {
@@ -37,7 +38,7 @@ struct MessageTextView: View {
     }
 
     var urlsToPreview: [URL] {
-        Array(styledText.urls.prefix(messageLinkPreviewLimit))
+        Array(styledText.urls.filter(shouldShowLinkPreview).prefix(messageLinkPreviewLimit))
     }
 
     var body: some View {
@@ -65,10 +66,14 @@ struct MessageTextView_Previews: PreviewProvider {
         MessageTextView(
             text: "Look at [this website](https://example.org)",
             messageStyler: AttributedString.init, userType: .other,
-            messageLinkPreviewLimit: 8)
+            shouldShowLinkPreview: { _ in true }, messageLinkPreviewLimit: 8)
         MessageTextView(
             text: "Look at [this website](https://example.org)",
             messageStyler: String.markdownStyler, userType: .other,
-            messageLinkPreviewLimit: 8)
+            shouldShowLinkPreview: { _ in true }, messageLinkPreviewLimit: 8)
+        MessageTextView(
+            text: "[@Dan](mention://user/123456789) look at [this website](https://example.org)!",
+            messageStyler: String.markdownStyler, userType: .other,
+            shouldShowLinkPreview: { $0.scheme != "mention" }, messageLinkPreviewLimit: 8)
     }
 }

--- a/Sources/ExyteChat/Views/MessageView/MessageView.swift
+++ b/Sources/ExyteChat/Views/MessageView/MessageView.swift
@@ -20,6 +20,7 @@ struct MessageView: View {
     let avatarSize: CGFloat
     let tapAvatarClosure: ChatView.TapAvatarClosure?
     let messageStyler: (String) -> AttributedString
+    let shouldShowLinkPreview: (URL) -> Bool
     let isDisplayingMessageMenu: Bool
     let showMessageTimeView: Bool
     let messageLinkPreviewLimit: Int
@@ -193,7 +194,8 @@ struct MessageView: View {
             if !message.text.isEmpty {
                 MessageTextView(
                     text: message.text, messageStyler: messageStyler,
-                    userType: message.user.type, messageLinkPreviewLimit: messageLinkPreviewLimit
+                    userType: message.user.type, shouldShowLinkPreview: shouldShowLinkPreview,
+                    messageLinkPreviewLimit: messageLinkPreviewLimit
                 )
                 .padding(.horizontal, MessageView.horizontalTextPadding)
             }
@@ -254,7 +256,8 @@ struct MessageView: View {
     func textWithTimeView(_ message: Message) -> some View {
         let messageView = MessageTextView(
             text: message.text, messageStyler: messageStyler,
-            userType: message.user.type, messageLinkPreviewLimit: messageLinkPreviewLimit
+            userType: message.user.type, shouldShowLinkPreview: shouldShowLinkPreview,
+            messageLinkPreviewLimit: messageLinkPreviewLimit
         )
         .fixedSize(horizontal: false, vertical: true)
         .padding(.horizontal, MessageView.horizontalTextPadding)
@@ -396,6 +399,7 @@ struct MessageView_Preview: PreviewProvider {
                 avatarSize: 32,
                 tapAvatarClosure: nil,
                 messageStyler: AttributedString.init,
+                shouldShowLinkPreview: { _ in true },
                 isDisplayingMessageMenu: false,
                 showMessageTimeView: true,
                 messageLinkPreviewLimit: 8,

--- a/Sources/ExyteChat/Views/UIList.swift
+++ b/Sources/ExyteChat/Views/UIList.swift
@@ -37,6 +37,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
     let tapAvatarClosure: ChatView.TapAvatarClosure?
     let paginationHandler: PaginationHandler?
     let messageStyler: (String) -> AttributedString
+    let shouldShowLinkPreview: (URL) -> Bool
     let showMessageTimeView: Bool
     let messageLinkPreviewLimit: Int
     let messageFont: UIFont
@@ -366,7 +367,8 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
             headerBuilder: headerBuilder, type: type, showDateHeaders: showDateHeaders,
             avatarSize: avatarSize, showMessageMenuOnLongPress: showMessageMenuOnLongPress,
             tapAvatarClosure: tapAvatarClosure, paginationHandler: paginationHandler,
-            messageStyler: messageStyler, showMessageTimeView: showMessageTimeView,
+            messageStyler: messageStyler, shouldShowLinkPreview: shouldShowLinkPreview,
+            showMessageTimeView: showMessageTimeView,
             messageLinkPreviewLimit: messageLinkPreviewLimit, messageFont: messageFont,
             sections: sections, ids: ids, mainBackgroundColor: theme.colors.mainBG,
             listSwipeActions: listSwipeActions)
@@ -391,6 +393,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
         let tapAvatarClosure: ChatView.TapAvatarClosure?
         let paginationHandler: PaginationHandler?
         let messageStyler: (String) -> AttributedString
+        let shouldShowLinkPreview: (URL) -> Bool
         let showMessageTimeView: Bool
         let messageLinkPreviewLimit: Int
         let messageFont: UIFont
@@ -414,7 +417,8 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
             headerBuilder: ((Date) -> AnyView)?, type: ChatType, showDateHeaders: Bool,
             avatarSize: CGFloat, showMessageMenuOnLongPress: Bool,
             tapAvatarClosure: ChatView.TapAvatarClosure?, paginationHandler: PaginationHandler?,
-            messageStyler: @escaping (String) -> AttributedString, showMessageTimeView: Bool,
+            messageStyler: @escaping (String) -> AttributedString,
+            shouldShowLinkPreview: @escaping (URL) -> Bool, showMessageTimeView: Bool,
             messageLinkPreviewLimit: Int, messageFont: UIFont, sections: [MessagesSection],
             ids: [String], mainBackgroundColor: Color, paginationTargetIndexPath: IndexPath? = nil,
             listSwipeActions: ListSwipeActions
@@ -433,6 +437,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
             self.tapAvatarClosure = tapAvatarClosure
             self.paginationHandler = paginationHandler
             self.messageStyler = messageStyler
+            self.shouldShowLinkPreview = shouldShowLinkPreview
             self.showMessageTimeView = showMessageTimeView
             self.messageLinkPreviewLimit = messageLinkPreviewLimit
             self.messageFont = messageFont
@@ -565,8 +570,8 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
                 ChatMessageView(
                     viewModel: viewModel, messageBuilder: messageBuilder, row: row, chatType: type,
                     avatarSize: avatarSize, tapAvatarClosure: tapAvatarClosure,
-                    messageStyler: messageStyler, isDisplayingMessageMenu: false,
-                    showMessageTimeView: showMessageTimeView,
+                    messageStyler: messageStyler, shouldShowLinkPreview: shouldShowLinkPreview,
+                    isDisplayingMessageMenu: false, showMessageTimeView: showMessageTimeView,
                     messageLinkPreviewLimit: messageLinkPreviewLimit, messageFont: messageFont
                 )
                 .transition(.scale)


### PR DESCRIPTION
# Example

This commit allows you to decide which URLs to show link previews for.

For instance, if you want to represent user tags as links using the `mention` scheme like `mention://user/123456789`, you could hide link previews for these links like so:

```swift
ChatView(...) { ... }
.shouldShowLinkPreview({ url in
    url.scheme != "mention"
})
```

| Input | Styled |
| ----- | ----- |
| ![input-text](https://github.com/user-attachments/assets/8d55d10c-d283-4cc5-bb0a-57ae3eeca153) | ![styled-text](https://github.com/user-attachments/assets/2f4d2d4a-91c3-49e2-a8d2-2804c3d9f976) |


# Description

We currently show a link preview for every link in a message. This assumes that links will only be used for representing content, which tends to be previewable thanks to the `LPMetadataProvider`.

However, some consumers want to override the `OpenURLAction` to implement mentions, or other behaviour that stays within the app and is more of an "action" than "content". In these cases, link previews don't make sense; it would be annoying to view link previews every time a specific user gets mentioned.

In theory, whether content is previewable could be allowlisted or denylisted by looking at the URL scheme. `http` and `https` should clearly have link previews, while `mention` should probably not.

However, there is no definitive documentation from Apple that explains which URLs will get dedicated previews and which won't. I initially thought that link previews only supported the [Open Graph protocol](https://ogp.me) and therefore `http` and `https` - however, I discovered that Apple also generate bespoke previews for `mailto`, `tel`, `facetime`, `facetime-audio`, `sms`, `file` etc.

While [many of these are documented](https://developer.apple.com/library/archive/featuredarticles/iPhoneURLScheme_Reference/Introduction/Introduction.html#//apple_ref/doc/uid/TP40007899-CH1-SW1), some, such as `file` are not, which means that any allowlist approach would risk false negatives. In addition, Apple could always introduce more bespoke previews, or let apps show link previews for their own registered schemes, which would make the allowlist out of date and introduce a maintenance burden.

Therefore, let the consumer - who will know which URLs are specific to actions in their app - decide which URLs should be previewed, and which should not via a callback.

While we could just let consumers pass in a list of schemes to be denylisted, this relies on them using schemes to differentiate their links in the first place; they could just as easily represent mentions as links to user resources e.g. `https://example.org/user/123456789`.

Therefore, use a callback for maximum flexibility.

Closes #186