### PR TITLE
Remove unused pageSize from enableLoadMore

### DIFF
--- a/ChatExample/ChatExample/Screens/ChatExampleView.swift
+++ b/ChatExample/ChatExample/Screens/ChatExampleView.swift
@@ -25,7 +25,7 @@ struct ChatExampleView: View {
         ChatView(messages: viewModel.messages, chatType: .conversation) { draft in
             viewModel.send(draft: draft)
         }
-        .enableLoadMore(pageSize: 3) { message in
+        .enableLoadMore { message in
             await MainActor.run {
                 viewModel.loadMoreMessage(before: message)
             }

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ These use `AnyView`, so please try to keep them easy enough
 `setMediaPickerSelectionParameters` - a struct holding MediaPicker selection parameters (assetsPickerLimit and others like mediaType, selectionStyle, etc.).   
 `orientationHandler` - handle screen rotation
 
-`enableLoadMore(offset: Int, handler: @escaping ChatPaginationClosure)` - when user scrolls to `offset`-th message from the end, call the handler function, so the user can load more messages. NOTE: New messages won't appear in the chat unless it's scrolled up to the very top - it's an optimization. 
+`enableLoadMore(handler: @escaping ChatPaginationClosure)` - when user scrolls to the final message, call the handler function, to load more messages
 
 ### Customize default UI
 You can use `chatTheme` to customize colors and images of default UI. You can pass all/some colors and images:

--- a/Sources/ExyteChat/Managers/PaginationState.swift
+++ b/Sources/ExyteChat/Managers/PaginationState.swift
@@ -8,10 +8,8 @@ public typealias ChatPaginationClosure = @Sendable (Message) async -> Void
 
 final actor PaginationHandler: ObservableObject {
     let handleClosure: ChatPaginationClosure
-    let pageSize: Int
 
-    init(handleClosure: @escaping ChatPaginationClosure, pageSize: Int) {
+    init(handleClosure: @escaping ChatPaginationClosure) {
         self.handleClosure = handleClosure
-        self.pageSize = pageSize
     }
 }

--- a/Sources/ExyteChat/Views/ChatView.swift
+++ b/Sources/ExyteChat/Views/ChatView.swift
@@ -617,11 +617,11 @@ public extension ChatView {
         return view
     }
     
-    /// when user scrolls up to `pageSize`-th meassage, call the handler function, so user can load more messages
+    /// when user scrolls to the final message, call the handler function, to load more messages
     /// NOTE: doesn't work well with `isScrollEnabled` false
-    func enableLoadMore(pageSize: Int, _ handler: @escaping ChatPaginationClosure) -> ChatView {
+    func enableLoadMore(_ handler: @escaping ChatPaginationClosure) -> ChatView {
         var view = self
-        view.paginationHandler = PaginationHandler(handleClosure: handler, pageSize: pageSize)
+        view.paginationHandler = PaginationHandler(handleClosure: handler)
         return view
     }
     


### PR DESCRIPTION
# Description

Pagination offset (by which I mean the distance from the top message before we start loading more) used to be determined by the `offset` parameter passed to `enableLoadMore`, like so:

```swift
if ids.prefix(offset + 1).contains(message.id) {
    onEvent?(message)
}
```

This got changed in 568d00dc3f77324a21c3823a50797c599470cb28. Now, we rely on `paginationTargetIndexPath` instead, which is hardcoded to be the last already loaded message:

```swift
IndexPath(row: lastSection.rows.count - 1, section: sections.count - 1)
```

As a result, `pageSize` is no longer used. Remove it to make sure that consumers do not expect different behaviour when they modify the parameter.

# Comments

I was tempted to re-add that `offset` functionality, but this comment made me pause:

```swift
/// call pagination handler when this row is reached
/// without this there is a bug: during new cells insertion willDisplay is called one extra time for the cell which used to be the last one while it is being updated (its position in group is changed from first to middle)
```

I didn't quite understand it, is it saying that we don't want to call the pagination handler at all before we reach the last already loaded message?

Anyway, if you'd like me to look at adding that functionality back, I'd be more than happy to take a look, just didn't want to start making changes without understanding the history first :)