### PR TITLE
Cloudkit support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ iOSInjectionProject/
 
 /.build/
 GoogleService-Info.plist
+Instructions.md

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,50 @@
+{
+  "pins" : [
+    {
+      "identity" : "activityindicatorview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/exyte/ActivityIndicatorView",
+      "state" : {
+        "revision" : "36140867802ae4a1d2b11490bcbbefe058001d14",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "anchoredpopup",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/exyte/AnchoredPopup.git",
+      "state" : {
+        "revision" : "787f27027d3ef38c01469d228ce062ab4d5645f5",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "giphy-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Giphy/giphy-ios-sdk",
+      "state" : {
+        "revision" : "cdefbedc9f99d40cc64667a2bfaae67a1cf36fbb",
+        "version" : "2.2.12"
+      }
+    },
+    {
+      "identity" : "libwebp-xcode",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/libwebp-Xcode",
+      "state" : {
+        "revision" : "0d60654eeefd5d7d2bef3835804892c40225e8b2",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "mediapicker",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/exyte/MediaPicker.git",
+      "state" : {
+        "revision" : "c287ee410e5d9e9d642ed9c715042830f174a1d6",
+        "version" : "3.1.4"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Giphy/giphy-ios-sdk",
       "state" : {
-        "revision" : "cdefbedc9f99d40cc64667a2bfaae67a1cf36fbb",
-        "version" : "2.2.12"
+        "revision" : "37f5b1ff6cf8bc4a78c0bc5eb1b814381bac9580",
+        "version" : "2.2.16"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         ),
         .package(
            url: "https://github.com/Giphy/giphy-ios-sdk",
-           exact: "2.2.12"
+           from: "2.2.16"
         ),
     ],
     targets: [

--- a/Sources/ExyteChat/Extensions/AttributedString+Extensions.swift
+++ b/Sources/ExyteChat/Extensions/AttributedString+Extensions.swift
@@ -56,7 +56,7 @@ extension AttributedString {
 }
 
 public extension AttributedString {
-    public var urls: [URL] {
+    var urls: [URL] {
         runs[\.link].map { (link, range) in
             link?.absoluteURL
         }


### PR DESCRIPTION
This pull request introduces several changes across different files, focusing on improving functionality, updating dependencies, and refining code. The most significant updates include handling local file URLs in the `CachedAsyncImage` component, modifying the `AttributedString` extension for better accessibility, and updating the Giphy SDK dependency version.

### Updates to `CachedAsyncImage` functionality:
* Added support for loading images from local file URLs (`file://`) both synchronously during initialization and asynchronously during runtime. This includes new helper methods `localFileImage` and `loadLocalFileImageSync`. [[1]](diffhunk://#diff-023f6b85535a2c25008ff15b148bf949596933f5a5e89a6abb31e4c806cde1aaL307-R316) [[2]](diffhunk://#diff-023f6b85535a2c25008ff15b148bf949596933f5a5e89a6abb31e4c806cde1aaR326-R332) [[3]](diffhunk://#diff-023f6b85535a2c25008ff15b148bf949596933f5a5e89a6abb31e4c806cde1aaR369-R380) [[4]](diffhunk://#diff-023f6b85535a2c25008ff15b148bf949596933f5a5e89a6abb31e4c806cde1aaR397-R419)
* Enhanced logic to differentiate between local file URLs and remote URLs, ensuring optimized image loading behavior.

### Dependency updates:
* Updated the Giphy SDK version in `Package.swift` from `2.2.12` to `2.2.16` to ensure compatibility and access to the latest features.

### Code refinements:
* Removed redundant `public` modifier for the `urls` property in the `AttributedString` extension to streamline code visibility.

### Workspace configuration:
* Added a new `contents.xcworkspacedata` file to the `.swiftpm/xcode/package.xcworkspace` directory to configure the workspace.