### PR TITLE
Updating giphy

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         ),
         .package(
            url: "https://github.com/Giphy/giphy-ios-sdk",
-           exact: "2.2.12"
+           exact: "2.2.16"
         ),
     ],
     targets: [


### PR DESCRIPTION
To build testflight I have to follow the steps on here to provide the dysm.

https://github.com/Giphy/giphy-ios-sdk/blob/main/dsym.md

To do that I had to upgrade the dependency on giphy to allow my to get valid DYSM. I don't actually use giphy so not sure if there is an easier way.