### PR TITLE
feat: make keyboard dismiss mode configurable in ChatView

### DIFF
--- a/ChatExample/ChatExample/Screens/ChatExampleView.swift
+++ b/ChatExample/ChatExample/Screens/ChatExampleView.swift
@@ -30,6 +30,7 @@ struct ChatExampleView: View {
                 viewModel.loadMoreMessage(before: message)
             }
         }
+        .keyboardDismissMode(.interactive)
         .messageUseMarkdown(true)
         .setRecorderSettings(recorderSettings)
         .messageReactionDelegate(viewModel)

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ These use `AnyView`, so please try to keep them easy enough
 `isScrollEnabled` - forbid scrolling for messages' `UITableView`   
 `showMessageMenuOnLongPress` - turn menu on long tap on/off    
 `showNetworkConnectionProblem` - display network error on/off    
+`keyboardDismissMode` - set keyboard dismiss mode for the chat list (.interactive, .onDrag, or .none), default is .none    
 `assetsPickerLimit` - set a limit for MediaPicker built into the library   
 `setMediaPickerSelectionParameters` - a struct holding MediaPicker selection parameters (assetsPickerLimit and others like mediaType, selectionStyle, etc.).   
 `orientationHandler` - handle screen rotation

--- a/Sources/ExyteChat/Views/ChatView.swift
+++ b/Sources/ExyteChat/Views/ChatView.swift
@@ -127,6 +127,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
     var availableInputs: [AvailableInputType] = [.text, .audio, .giphy, .media]
     var recorderSettings: RecorderSettings = RecorderSettings()
     var listSwipeActions: ListSwipeActions = ListSwipeActions()
+    var keyboardDismissMode: UIScrollView.KeyboardDismissMode = .none
     
     @StateObject private var viewModel = ChatViewModel()
     @StateObject private var inputViewModel = InputViewModel()
@@ -341,7 +342,8 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
             messageFont: messageFont,
             sections: sections,
             ids: ids,
-            listSwipeActions: listSwipeActions
+            listSwipeActions: listSwipeActions,
+            keyboardDismissMode: keyboardDismissMode
         )
         .applyIf(!isScrollEnabled) {
             $0.frame(height: tableContentHeight)
@@ -590,6 +592,15 @@ public extension ChatView {
     func showMessageMenuOnLongPress(_ show: Bool) -> ChatView {
         var view = self
         view.showMessageMenuOnLongPress = show
+        return view
+    }
+    
+    /// Sets the keyboard dismiss mode for the chat list
+    /// - Parameter mode: The keyboard dismiss mode (.interactive, .onDrag, or .none)
+    /// - Default is .none
+    func keyboardDismissMode(_ mode: UIScrollView.KeyboardDismissMode) -> ChatView {
+        var view = self
+        view.keyboardDismissMode = mode
         return view
     }
     

--- a/Sources/ExyteChat/Views/UIList.swift
+++ b/Sources/ExyteChat/Views/UIList.swift
@@ -44,6 +44,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
     let sections: [MessagesSection]
     let ids: [String]
     let listSwipeActions: ListSwipeActions
+    let keyboardDismissMode: UIScrollView.KeyboardDismissMode
 
     @State var isScrolledToTop = false
     @State var updateQueue = UpdateQueue()
@@ -63,6 +64,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
         tableView.backgroundColor = UIColor(theme.colors.mainBG)
         tableView.scrollsToTop = false
         tableView.isScrollEnabled = isScrollEnabled
+        tableView.keyboardDismissMode = keyboardDismissMode
 
         NotificationCenter.default.addObserver(forName: .onScrollToBottom, object: nil, queue: nil) { _ in
             DispatchQueue.main.async {
@@ -371,7 +373,8 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
             showMessageTimeView: showMessageTimeView,
             messageLinkPreviewLimit: messageLinkPreviewLimit, messageFont: messageFont,
             sections: sections, ids: ids, mainBackgroundColor: theme.colors.mainBG,
-            listSwipeActions: listSwipeActions)
+            listSwipeActions: listSwipeActions,
+            keyboardDismissMode: keyboardDismissMode)
     }
 
     class Coordinator: NSObject, UITableViewDataSource, UITableViewDelegate {
@@ -407,6 +410,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
         let ids: [String]
         let mainBackgroundColor: Color
         let listSwipeActions: ListSwipeActions
+        let keyboardDismissMode: UIScrollView.KeyboardDismissMode
 
         private let impactGenerator = UIImpactFeedbackGenerator(style: .heavy)
 
@@ -421,7 +425,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
             shouldShowLinkPreview: @escaping (URL) -> Bool, showMessageTimeView: Bool,
             messageLinkPreviewLimit: Int, messageFont: UIFont, sections: [MessagesSection],
             ids: [String], mainBackgroundColor: Color, paginationTargetIndexPath: IndexPath? = nil,
-            listSwipeActions: ListSwipeActions
+            listSwipeActions: ListSwipeActions, keyboardDismissMode: UIScrollView.KeyboardDismissMode
         ) {
             self.viewModel = viewModel
             self.inputViewModel = inputViewModel
@@ -446,6 +450,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
             self.mainBackgroundColor = mainBackgroundColor
             self.paginationTargetIndexPath = paginationTargetIndexPath
             self.listSwipeActions = listSwipeActions
+            self.keyboardDismissMode = keyboardDismissMode
         }
 
         /// call pagination handler when this row is reached


### PR DESCRIPTION
### Add configurable keyboard dismiss mode to ChatView

This PR adds the ability to configure keyboard dismiss behavior when scrolling through chat messages, providing native chat experience like WhatsApp/Telegram.

**What's changed:**
- Added `keyboardDismissMode` property to ChatView (defaults to `.none`)
- Updated UIList to use configurable dismiss mode
- Default is none because its none by default in tableView

**Usage:**
```swift
ChatView(messages: messages) { draft in }
    .keyboardDismissMode(.interactive)
```

**Why this matters:**
Previous attempt ([PR #133](https://github.com/exyte/Chat/pull/133)) used drag gestures on InputView but didn't provide proper native chat keyboard behavior. This implementation works exactly like popular messaging apps with interactive keyboard dismissal during scrolling.