### PR TITLE
Fix crash when adding giphy media

### DIFF
--- a/Sources/ExyteChat/Views/Giphy/GiphyMediaView.swift
+++ b/Sources/ExyteChat/Views/Giphy/GiphyMediaView.swift
@@ -11,7 +11,7 @@ struct GiphyMediaView: UIViewRepresentable {
         let view = GPHMediaView()
         GiphyCore.shared.gifByID(id) { (response, error) in
             if let media = response?.data {
-                DispatchQueue.main.sync {
+                DispatchQueue.main.async {
                     view.setMedia(media)
                     self.aspectRatio = media.aspectRatio
                 }


### PR DESCRIPTION
Updating the giphy library version caused the code to start crashing when adding giphy media.  
The issue was due to our code syncing on the main thread when already on the main thread causing the code to crash.  
This pull request fixes this bug.  
I've raised an issue with the GiphySdk for them to update there docs as they currently include this error https://github.com/Giphy/giphy-ios-sdk/issues/287

