### PR TITLE
Fix message layout when sending short text with newlines

### DIFF
--- a/Sources/ExyteChat/Views/MessageView/MessageView.swift
+++ b/Sources/ExyteChat/Views/MessageView/MessageView.swift
@@ -282,8 +282,10 @@ struct MessageView: View {
             messageLinkPreviewLimit: messageLinkPreviewLimit
         )
         .fixedSize(horizontal: false, vertical: true)
+        .padding(.horizontal, MessageView.horizontalTextPadding)
 
         let timeView = messageTimeView()
+            .padding(.horizontal, 12)
 
         Group {
             switch dateArrangement {
@@ -311,7 +313,6 @@ struct MessageView: View {
                     }
             }
         }
-        .padding(.horizontal, MessageView.horizontalTextPadding)
     }
 
     @ViewBuilder

--- a/Sources/ExyteChat/Views/MessageView/MessageView.swift
+++ b/Sources/ExyteChat/Views/MessageView/MessageView.swift
@@ -204,7 +204,8 @@ struct MessageView: View {
                 MessageTextView(
                     text: message.text, messageStyler: messageStyler,
                     userType: message.user.type, shouldShowLinkPreview: shouldShowLinkPreview,
-                    messageLinkPreviewLimit: messageLinkPreviewLimit
+                    messageLinkPreviewLimit: messageLinkPreviewLimit,
+                    isDeleted: message.isDeleted
                 )
                 .padding(.horizontal, MessageView.horizontalTextPadding)
             }
@@ -279,13 +280,12 @@ struct MessageView: View {
         let messageView = MessageTextView(
             text: message.text, messageStyler: messageStyler,
             userType: message.user.type, shouldShowLinkPreview: shouldShowLinkPreview,
-            messageLinkPreviewLimit: messageLinkPreviewLimit
+            messageLinkPreviewLimit: messageLinkPreviewLimit,
+            isDeleted: message.isDeleted
         )
         .fixedSize(horizontal: false, vertical: true)
-        .padding(.horizontal, MessageView.horizontalTextPadding)
 
         let timeView = messageTimeView()
-            .padding(.trailing, 12)
 
         Group {
             switch dateArrangement {
@@ -313,6 +313,7 @@ struct MessageView: View {
                     }
             }
         }
+        .padding(.horizontal, MessageView.horizontalTextPadding)
     }
 
     @ViewBuilder
@@ -376,6 +377,7 @@ extension View {
         static let john = User(id: "john", name: "John", avatarURL: nil, isCurrentUser: true)
 
         static private var extraShortText = "Sss"
+        static private var extraShortTextWithNewline = "H\nJ"
         static private var shortText = "Hi, buddy!"
         static private var longText =
             "Hello hello hello hello hello hello hello hello hello hello hello hello hello\n hello hello hello hello d d d d d d d d"
@@ -432,25 +434,51 @@ extension View {
             text: extraShortText
         )
 
+        static private var extrShortMessage = Message(
+            id: UUID().uuidString,
+            user: stan,
+            status: .read,
+            text: extraShortTextWithNewline
+        )
+        
         static var previews: some View {
             ZStack {
                 Color.yellow.ignoresSafeArea()
-
-                MessageView(
-                    viewModel: ChatViewModel(),
-                    message: replyedMessage,
-                    positionInUserGroup: .single,
-                    positionInMessagesSection: .single,
-                    chatType: .conversation,
-                    avatarSize: 32,
-                    tapAvatarClosure: nil,
-                    messageStyler: AttributedString.init,
-                    shouldShowLinkPreview: { _ in true },
-                    isDisplayingMessageMenu: false,
-                    showMessageTimeView: true,
-                    messageLinkPreviewLimit: 8,
-                    font: UIFontMetrics.default.scaledFont(for: UIFont.systemFont(ofSize: 15))
-                )
+                
+                VStack {
+                    MessageView(
+                        viewModel: ChatViewModel(),
+                        message: extrShortMessage,
+                        positionInUserGroup: .single,
+                        positionInMessagesSection: .single,
+                        chatType: .conversation,
+                        avatarSize: 32,
+                        tapAvatarClosure: nil,
+                        messageStyler: AttributedString.init,
+                        shouldShowLinkPreview: { _ in true },
+                        isDisplayingMessageMenu: false,
+                        showMessageTimeView: true,
+                        messageLinkPreviewLimit: 8,
+                        font: UIFontMetrics.default.scaledFont(for: UIFont.systemFont(ofSize: 15))
+                    )
+                    
+                    MessageView(
+                        viewModel: ChatViewModel(),
+                        message: replyedMessage,
+                        positionInUserGroup: .single,
+                        positionInMessagesSection: .single,
+                        chatType: .conversation,
+                        avatarSize: 32,
+                        tapAvatarClosure: nil,
+                        messageStyler: AttributedString.init,
+                        shouldShowLinkPreview: { _ in true },
+                        isDisplayingMessageMenu: false,
+                        showMessageTimeView: true,
+                        messageLinkPreviewLimit: 8,
+                        font: UIFontMetrics.default.scaledFont(for: UIFont.systemFont(ofSize: 15))
+                    )
+                }
+                
             }
         }
     }

--- a/Sources/ExyteChat/Views/MessageView/MessageView.swift
+++ b/Sources/ExyteChat/Views/MessageView/MessageView.swift
@@ -204,8 +204,7 @@ struct MessageView: View {
                 MessageTextView(
                     text: message.text, messageStyler: messageStyler,
                     userType: message.user.type, shouldShowLinkPreview: shouldShowLinkPreview,
-                    messageLinkPreviewLimit: messageLinkPreviewLimit,
-                    isDeleted: message.isDeleted
+                    messageLinkPreviewLimit: messageLinkPreviewLimit
                 )
                 .padding(.horizontal, MessageView.horizontalTextPadding)
             }
@@ -280,8 +279,7 @@ struct MessageView: View {
         let messageView = MessageTextView(
             text: message.text, messageStyler: messageStyler,
             userType: message.user.type, shouldShowLinkPreview: shouldShowLinkPreview,
-            messageLinkPreviewLimit: messageLinkPreviewLimit,
-            isDeleted: message.isDeleted
+            messageLinkPreviewLimit: messageLinkPreviewLimit
         )
         .fixedSize(horizontal: false, vertical: true)
 


### PR DESCRIPTION
This PR fixes #216 

- Fix message view padding
- add preview views

Before


https://github.com/user-attachments/assets/5352b788-6fef-49d5-b4cd-ae8ef18e4f0a

After


https://github.com/user-attachments/assets/76e80c18-0050-4378-9230-deae39890daf

