### PR TITLE
fix: Add KeyboardState to AttachmentsEditor to prevent crash in signature mode

### DIFF
--- a/Sources/ExyteChat/Views/ChatView.swift
+++ b/Sources/ExyteChat/Views/ChatView.swift
@@ -232,6 +232,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
                     localization: localization
                 )
                 .environmentObject(globalFocusState)
+                .environmentObject(keyboardState)
             }
         
             .onChange(of: inputViewModel.showPicker) { _ , newValue in


### PR DESCRIPTION
Fixes crash when dismissing keyboard via gesture in signature input view by providing the missing KeyboardState environment object.

Crashlytic Log:
SwiftUICore/EnvironmentObject.swift:92: Fatal error: No ObservableObject of type KeyboardState found. A View.environmentObject(_:) for KeyboardState may be missing as an ancestor of this view.

The AttachmentsEditor expects keyboardState at line 20 but it wasn't provided.