### PR TITLE
Provide a fallback edit action icon for iOS 17

### DIFF
--- a/Sources/ExyteChat/Views/MessageView/MessageMenu/MessageMenu+Action.swift
+++ b/Sources/ExyteChat/Views/MessageView/MessageMenu/MessageMenu+Action.swift
@@ -42,7 +42,11 @@ public enum DefaultMessageMenuAction: MessageMenuAction, Sendable {
         case .reply:
             Image(systemName: "arrowshape.turn.up.left")
         case .edit:
-            Image(systemName: "bubble.and.pencil")
+            if #available(iOS 18.0, macCatalyst 18.0, *) {
+                Image(systemName: "bubble.and.pencil")
+            } else {
+                Image(systemName: "square.and.pencil")
+            }
         }
     }
 


### PR DESCRIPTION
The bubble.and.pencil icon is only available on iOS 18+

This prevents the edit action from having no icon on iOS 17