### PR TITLE
fix onScrollToBottom to avoid crash

### DIFF
--- a/Sources/ExyteChat/Views/UIList.swift
+++ b/Sources/ExyteChat/Views/UIList.swift
@@ -69,6 +69,7 @@ struct UIList<MessageContent: View, InputView: View>: UIViewRepresentable {
         NotificationCenter.default.addObserver(forName: .onScrollToBottom, object: nil, queue: nil) { _ in
             DispatchQueue.main.async {
                 if !context.coordinator.sections.isEmpty {
+                    guard tableView.numberOfSections > 0, tableView.numberOfRows(inSection: 0) > 0 else { return }
                     tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .bottom, animated: true)
                 }
             }


### PR DESCRIPTION
Fix crash when updating view and scrolling to bottom

 updating the view while scrolling to the bottom  to bottom caused a crash
<img width="1512" height="982" alt="Capture d’écran 2025-12-03 à 17 19 38" src="https://github.com/user-attachments/assets/69f0b2f7-1247-4e0a-a207-0c78a86a6991" />
