### PR TITLE
Fix duplicate 'Examples' section heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ https://firebase.google.com/docs/firestore/manage-data/add-data
 Create cloud firestore database (for images and voice recordings)
 https://firebase.google.com/docs/storage/web/start
 
-## Examples
+## Running the Examples
 
 To try the Chat examples:
 - Clone the repo `https://github.com/exyte/Chat.git`


### PR DESCRIPTION
## Summary
- Fixed duplicate "Examples" section heading in README.md
- Changed second occurrence to "Running the Examples" for better clarity
- First section (line 431) describes what the example projects are
- Second section (line 443) explains how to run them

## Changes
- Renamed second "## Examples" heading to "## Running the Examples"

This improves documentation structure and makes it easier for readers to find specific information about the example projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)