### PR TITLE
Fix swift-format link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please use selected code formatting style:
 
 ### swift-format
 
-You can use [swift-format](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwjol7H-_6iLAxW5ZmwGHViJIX8QFnoECBoQAQ&url=https%3A%2F%2Fgithub.com%2Fswiftlang%2Fswift-format&usg=AOvVaw0kMi_vMj0IW_Vm5BZ8ffcT&opi=89978449) to do this
+You can use [swift-format](https://github.com/swiftlang/swift-format) to do this
 
 Code style is specified in .swift-format
 Run swift-format before checkin to ensure matching code style


### PR DESCRIPTION
## Summary
- Replaced Google redirect URL with direct link to swift-format repository
- Improves readability and maintainability of CONTRIBUTING.md

## Changes
- Changed link from long Google redirect URL to `https://github.com/swiftlang/swift-format`

The previous URL was a Google search redirect that was unnecessarily long and difficult to read. This PR replaces it with a direct link to the official swift-format repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)