### PR TITLE
Fix method name typo in README: setAvailableInput -> setAvailableInputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ By default the built-in MediaPicker will be auto-customized using the most logic
 `setMessageFont` - pass custom font to use for messages   
 
 ### makes sense only for built-in input view
-`setAvailableInput` - hide some buttons in default InputView. Available options are:    
+`setAvailableInputs` - hide some buttons in default InputView. Available options are:    
     - `.full` - media + text + audio   
     - `.textAndMedia`   
     - `.textAndAudio`   


### PR DESCRIPTION
## Summary
- Fixed typo in README.md modifier documentation
- Changed `setAvailableInput` to `setAvailableInputs` (plural)

## Changes
- Line 307: Corrected method name to match actual API

## Details
The actual method in `ChatView.swift` (line 719) is `setAvailableInputs` with plural "Inputs". The README documentation incorrectly showed it as singular. The example code on line 372 already uses the correct plural form `.setAvailableInputs([.text, .giphy])`.

This fix ensures consistency between the documentation and the actual API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)