### PR TITLE
Fix a crash in the audio recorder on small screens

### DIFF
--- a/Sources/ExyteChat/Views/Recording/RecordWaveform.swift
+++ b/Sources/ExyteChat/Views/Recording/RecordWaveform.swift
@@ -142,21 +142,17 @@ struct RecordWaveformPlaying: View {
     func adjustedSamples(_ maxWidth: CGFloat) -> [CGFloat] {
         // Don't set maxSamples as Int, as casting to Int can make it zero, and we divide by it later.
         let maxSamples = (maxWidth - RecordWaveformWithButtons.viewPadding) / (RecordWaveform.width + RecordWaveform.spacing)
-        let temp = samples
-        
-        if Double(temp.count) <= maxSamples {
-            return temp
+
+        if Double(samples.count) <= maxSamples {
+            return samples
         }
 
         // use ceil to ensure that the adjusted.count will not be greater than maxSamples
-        let ratio = Int(ceil( Double(temp.count) / maxSamples ))
-
-        let adjusted = stride(from: 0, to: temp.count, by: ratio).map {
-            temp[$0]
+        let ratio = Int(ceil( Double(samples.count) / maxSamples ))
+        let adjusted = stride(from: 0, to: samples.count, by: ratio).map {
+            samples[$0]
         }
-        
         return adjusted
-        
     }
 }
 

--- a/Sources/ExyteChat/Views/Recording/RecordWaveform.swift
+++ b/Sources/ExyteChat/Views/Recording/RecordWaveform.swift
@@ -140,19 +140,18 @@ struct RecordWaveformPlaying: View {
     }
 
     func adjustedSamples(_ maxWidth: CGFloat) -> [CGFloat] {
-        let maxSamples = Int((maxWidth - RecordWaveformWithButtons.viewPadding) / (RecordWaveform.width + RecordWaveform.spacing))
+        // Don't set maxSamples as Int, as casting to Int can make it zero, and we divide by it later.
+        let maxSamples = (maxWidth - RecordWaveformWithButtons.viewPadding) / (RecordWaveform.width + RecordWaveform.spacing)
         let temp = samples
         
-        if temp.count <= maxSamples {
+        if Double(temp.count) <= maxSamples {
             return temp
         }
 
         // use ceil to ensure that the adjusted.count will not be greater than maxSamples
-        let ratio = Int(ceil( Double(temp.count) / Double(maxSamples) ))
-        // Ensure ratio is at least 1 to prevent zero stride error
-        let safeRatio = max(1, ratio)
+        let ratio = Int(ceil( Double(temp.count) / maxSamples ))
 
-        let adjusted = stride(from: 0, to: temp.count, by: safeRatio).map {
+        let adjusted = stride(from: 0, to: temp.count, by: ratio).map {
             temp[$0]
         }
         


### PR DESCRIPTION
On the iPhone SE (4.7"), `maxWidth` is sometimes equal to `161.5` and sometimes equal to `375`.
In the former case, `maxSamples` is `0.375`
This leads to a division by zero crash, caused by casting to `Int` before dividing.
This PR fixes the crash by removing the cast before the division.

Note: while this PR fixes the crash (and cleans up the code a bit), it doesn't address the root cause: `UIScreen.main.bounds.width` is returning different values (without me changing the screen orientation).
https://github.com/exyte/Chat/blob/db315110c228e8b6e152f2d65d66051f9853b418/Sources/ExyteChat/Views/Recording/RecordWaveform.swift#L94
In fact, if I add a debug print to the `adjustedSamples` function, this is the output when I click the stop button on an audio recording:
```
maxWidth = 375.0
maxWidth = 161.5
maxWidth = 375.0
maxWidth = 161.5
maxWidth = 375.0
maxWidth = 161.5
```
The change in value returned by `UIScreen.main.bounds.width` might be because it's called inside the initializer of a View.