### PR TITLE
Fix compatibility with MediaPicker 3.3.0

### DIFF
--- a/Sources/ExyteChat/Views/ChatView.swift
+++ b/Sources/ExyteChat/Views/ChatView.swift
@@ -10,8 +10,8 @@ import GiphyUISDK
 import ExyteMediaPicker
 
 public typealias MediaPickerLiveCameraStyle = LiveCameraCellStyle
-public typealias MediaPickerSelectionParameters = SelectionParamsHolder
-public typealias MediaPickerParameters = MediaPickerParamsHolder
+public typealias MediaPickerSelectionParameters = SelectionParameters
+public typealias MediaPickerParameters = MediaPickerCutomizationParameters
 
 public enum ChatType: CaseIterable, Sendable {
     case conversation // the latest message is at the bottom, new messages appear from the bottom


### PR DESCRIPTION
## Summary

MediaPicker 3.3.0 renamed `SelectionParamsHolder` to `SelectionParameters` and `MediaPickerParamsHolder` to `MediaPickerCutomizationParameters`. This updates the typealiases in `ChatView.swift` to use the new names, fixing a build failure when resolving MediaPicker >= 3.3.0.

Fixes https://github.com/exyte/Chat/issues/260

## Changes

- `SelectionParamsHolder` → `SelectionParameters`
- `MediaPickerParamsHolder` → `MediaPickerCutomizationParameters`