### PR TITLE
Fix optional params for MediaPicker 3.3.0

### DIFF
--- a/Sources/ExyteChat/Views/Attachments/AttachmentsEditor.swift
+++ b/Sources/ExyteChat/Views/Attachments/AttachmentsEditor.swift
@@ -81,8 +81,8 @@ struct AttachmentsEditor<InputViewContent: View>: View {
                 inputViewModel.showPicker = false
             }
             .currentFullscreenMedia($currentFullscreenMedia)
-            .setSelectionParameters(mediaPickerSelectionParameters)
-            .setMediaPickerParameters(mediaPickerParameters)
+            .setSelectionParameters(mediaPickerSelectionParameters ?? SelectionParameters())
+            .setMediaPickerParameters(mediaPickerParameters ?? MediaPickerCutomizationParameters())
             .pickerMode($inputViewModel.mediaPickerMode)
             .orientationHandler(orientationHandler)
             .padding(.top)


### PR DESCRIPTION
## Summary

MediaPicker 3.3.0 changed `setSelectionParameters` and `setMediaPickerParameters` to accept non-optional parameters. This fixes the call sites in `AttachmentsEditor.swift` by providing default instances when the values are nil, matching the previous guard-let-else-return behavior.

## Changes

- Pass `SelectionParameters()` and `MediaPickerCutomizationParameters()` as defaults when the optional values are nil