### PR TITLE
Support partial customization of chat messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ ChatView(messages: viewModel.messages) { draft in
     }
 }
 ```
-To customize only some messages while keeping the default style for others, use `messageBuilder` and return your custom view for the messages you want to style, and `DefaultMessageView(params:)` for the rest. This way you can mix custom message cards with ExyteChat's built-in styling in the same chat.
+To customize only some messages while keeping the default style for others, use `messageBuilder` and return your custom view for the messages you want to style, and `params.defaultMessageView()` for the rest. This way you can mix custom message cards with ExyteChat's built-in styling in the same chat.
 
 ```swift
 ChatView(messages: viewModel.messages) { draft in
@@ -126,7 +126,7 @@ ChatView(messages: viewModel.messages) { draft in
     if needsCustomUI(params.message) {
         MyCustomMessageView(message: params.message)
     } else {
-        DefaultMessageView(params: params)
+        params.defaultMessageView()
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -117,6 +117,20 @@ ChatView(messages: viewModel.messages) { draft in
     }
 }
 ```
+To customize only some messages while keeping the default style for others, use `messageBuilder` and return your custom view for the messages you want to style, and `DefaultMessageView(params:)` for the rest. This way you can mix custom message cards with ExyteChat's built-in styling in the same chat.
+
+```swift
+ChatView(messages: viewModel.messages) { draft in
+    viewModel.send(draft: draft)
+} messageBuilder: { params in
+    if needsCustomUI(params.message) {
+        MyCustomMessageView(message: params.message)
+    } else {
+        DefaultMessageView(params: params)
+    }
+}
+```
+
 `messageBuilder`'s parameters:  
 - `message` - the message containing user info, attachments, etc.   
 - `positionInUserGroup` - the position of the message in its continuous collection of messages from the same user    
@@ -509,4 +523,3 @@ dependencies: [
 [FlagAndCountryCode](https://github.com/exyte/FlagAndCountryCode) - Phone codes and flags for every country    
 [SVGView](https://github.com/exyte/SVGView) - SVG parser    
 [LiquidSwipe](https://github.com/exyte/LiquidSwipe) - Liquid navigation animation
-

--- a/Sources/ExyteChat/Views/ChatBuilderParameters.swift
+++ b/Sources/ExyteChat/Views/ChatBuilderParameters.swift
@@ -23,6 +23,10 @@ public struct MessageBuilderParameters {
     public let showContextMenuClosure: () -> Void
     public let messageActionClosure: (Message, DefaultMessageMenuAction) -> Void
     public let showAttachmentClosure: (Attachment) -> Void
+
+    @MainActor public func defaultMessageView() -> some View {
+        DefaultMessageView(params: self)
+    }
 }
 
 /// To build a custom input view use the following parameters passed by builder closure:

--- a/Sources/ExyteChat/Views/ChatView.swift
+++ b/Sources/ExyteChat/Views/ChatView.swift
@@ -35,7 +35,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
 
     /// provide custom message view builder
     /// To customize only some messages while keeping the default style for others,
-    /// use `messageBuilder` and return your custom view for the messages you want to style, and `DefaultMessageView(params:)` for the rest.
+    /// use `messageBuilder` and return your custom view for the messages you want to style, and `params.defaultMessageView()` for the rest.
     /// This way you can mix your custom message view with ExyteChat's built-in styling in the same chat.
     /// ```swift
     /// ChatView(messages: viewModel.messages) { draft in
@@ -44,7 +44,7 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
     ///     if needsCustomUI(params.message) {
     ///         MyCustomMessageView(message: params.message)
     ///     } else {
-    ///         DefaultMessageView(params: params)
+    ///         params.defaultMessageView()
     ///     }
     /// }
     /// ```

--- a/Sources/ExyteChat/Views/ChatView.swift
+++ b/Sources/ExyteChat/Views/ChatView.swift
@@ -34,6 +34,20 @@ public struct ChatView<MessageContent: View, InputViewContent: View, MenuAction:
     // MARK: - Parameters
 
     /// provide custom message view builder
+    /// To customize only some messages while keeping the default style for others,
+    /// use `messageBuilder` and return your custom view for the messages you want to style, and `DefaultMessageView(params:)` for the rest.
+    /// This way you can mix your custom message view with ExyteChat's built-in styling in the same chat.
+    /// ```swift
+    /// ChatView(messages: viewModel.messages) { draft in
+    ///     viewModel.send(draft: draft)
+    /// } messageBuilder: { params in
+    ///     if needsCustomUI(params.message) {
+    ///         MyCustomMessageView(message: params.message)
+    ///     } else {
+    ///         DefaultMessageView(params: params)
+    ///     }
+    /// }
+    /// ```
     @ViewBuilder var messageBuilder: MessageBuilderParamsClosure
 
     /// provide custom input view builder

--- a/Sources/ExyteChat/Views/MessageView/ChatMessageView.swift
+++ b/Sources/ExyteChat/Views/MessageView/ChatMessageView.swift
@@ -32,10 +32,11 @@ struct ChatMessageView<MessageContent: View>: View {
                     positionInMessagesSection: row.positionInMessagesSection,
                     positionInCommentsGroup: row.commentsPosition,
                     showContextMenuClosure: { viewModel.messageMenuRow = row },
-                    messageActionClosure: viewModel.messageMenuAction()
-                ) { attachment in
-                    self.viewModel.presentAttachmentFullScreen(attachment)
-                }
+                    messageActionClosure: viewModel.messageMenuAction(),
+                    showAttachmentClosure: { attachment in
+                        self.viewModel.presentAttachmentFullScreen(attachment)
+                    }
+                )
             )
 
             if customMessageView is DummyView {

--- a/Sources/ExyteChat/Views/MessageView/ChatMessageView.swift
+++ b/Sources/ExyteChat/Views/MessageView/ChatMessageView.swift
@@ -51,6 +51,11 @@ struct ChatMessageView<MessageContent: View>: View {
                 )
             } else {
                 customMessageView
+                    .environmentObject(viewModel)
+                    .environment(\.chatMessageType, chatType)
+                    .environment(\.messageCustomizationParams, messageParams)
+                    .environment(\.timeViewWidthBinding, $timeViewWidth)
+                    .environment(\.isDisplayingMessageMenu, isDisplayingMessageMenu)
             }
         }
         .id(row.message.id)

--- a/Sources/ExyteChat/Views/MessageView/DefaultMessageView.swift
+++ b/Sources/ExyteChat/Views/MessageView/DefaultMessageView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+public struct DefaultMessageView: View {
+    let params: MessageBuilderParameters
+
+    @EnvironmentObject private var viewModel: ChatViewModel
+    @Environment(\.chatMessageType) private var chatType
+    @Environment(\.messageCustomizationParams) private var customizationParams
+    @Environment(\.timeViewWidthBinding) private var timeViewWidth
+    @Environment(\.isDisplayingMessageMenu) private var isDisplayingMessageMenu
+
+    public init(params: MessageBuilderParameters) {
+        self.params = params
+    }
+
+    public var body: some View {
+        MessageView(
+            viewModel: viewModel,
+            message: params.message,
+            positionInUserGroup: params.positionInGroup,
+            positionInMessagesSection: params.positionInMessagesSection,
+            chatType: chatType,
+            params: customizationParams,
+            timeViewWidth: timeViewWidth,
+            isDisplayingMessageMenu: isDisplayingMessageMenu
+        )
+    }
+}

--- a/Sources/ExyteChat/Views/MessageView/DefaultMessageView.swift
+++ b/Sources/ExyteChat/Views/MessageView/DefaultMessageView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public struct DefaultMessageView: View {
+struct DefaultMessageView: View {
     let params: MessageBuilderParameters
 
     @EnvironmentObject private var viewModel: ChatViewModel
@@ -9,11 +9,11 @@ public struct DefaultMessageView: View {
     @Environment(\.timeViewWidthBinding) private var timeViewWidth
     @Environment(\.isDisplayingMessageMenu) private var isDisplayingMessageMenu
 
-    public init(params: MessageBuilderParameters) {
+    init(params: MessageBuilderParameters) {
         self.params = params
     }
 
-    public var body: some View {
+    var body: some View {
         MessageView(
             viewModel: viewModel,
             message: params.message,

--- a/Sources/ExyteChat/Views/MessageView/MessageViewEnvironment.swift
+++ b/Sources/ExyteChat/Views/MessageView/MessageViewEnvironment.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+private struct ChatMessageTypeEnvironmentKey: EnvironmentKey {
+    static let defaultValue: ChatType = .conversation
+}
+
+private struct MessageCustomizationParamsEnvironmentKey: EnvironmentKey {
+    static let defaultValue = MessageCustomizationParameters()
+}
+
+private struct TimeViewWidthBindingEnvironmentKey: EnvironmentKey {
+    static let defaultValue: Binding<CGFloat> = .constant(0)
+}
+
+private struct IsDisplayingMessageMenuEnvironmentKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var chatMessageType: ChatType {
+        get { self[ChatMessageTypeEnvironmentKey.self] }
+        set { self[ChatMessageTypeEnvironmentKey.self] = newValue }
+    }
+
+    var messageCustomizationParams: MessageCustomizationParameters {
+        get { self[MessageCustomizationParamsEnvironmentKey.self] }
+        set { self[MessageCustomizationParamsEnvironmentKey.self] = newValue }
+    }
+
+    var timeViewWidthBinding: Binding<CGFloat> {
+        get { self[TimeViewWidthBindingEnvironmentKey.self] }
+        set { self[TimeViewWidthBindingEnvironmentKey.self] = newValue }
+    }
+
+    var isDisplayingMessageMenu: Bool {
+        get { self[IsDisplayingMessageMenuEnvironmentKey.self] }
+        set { self[IsDisplayingMessageMenuEnvironmentKey.self] = newValue }
+    }
+}


### PR DESCRIPTION
## Summary
Adds support for mixing custom message rendering with ExyteChat's built-in default message UI.

## What changed
- Added `params.defaultMessageView()` for rendering the built-in message appearance.
- Updated the README to show how to customize only selected messages.

## Why
Apps sometimes need to override only a subset of messages. Before this change, they had to reimplement the default message layout for the rest, which made partial customization awkward and easy to drift from the library's styling.


## Related issue
- #264

Here is a demo screenshot:
<img width="1058" height="698" alt="image" src="https://github.com/user-attachments/assets/b83ad32c-30e2-47f6-a8e1-7debce54e6db" />
