### PR TITLE
fix: make message-bubble username font Dynamic Type-scalable

### DIFF
--- a/Sources/ExyteChat/Views/MessageView/MessageView.swift
+++ b/Sources/ExyteChat/Views/MessageView/MessageView.swift
@@ -159,7 +159,7 @@ struct MessageView: View {
             VStack(alignment: .leading, spacing: 4) {
                 if params.showUsername, !message.user.isCurrentUser {
                     Text(message.user.name)
-                        .font(.system(size: 12, weight: .bold))
+                        .font(.caption.weight(.bold))
                         .padding(.horizontal, MessageView.horizontalTextPadding)
                 }
 


### PR DESCRIPTION
## Why

Fixes #273.

The username \`Text\` in \`bubbleView\` is hard-coded to \`.font(.system(size: 12, weight: .bold))\`, so it ignores the user's preferred text size. The same surface in \`replyBubbleView\` already uses an inherited text style (\`.caption2\`) + \`.fontWeight(.semibold)\` and scales correctly, which is what the issue reporter pointed out as the inconsistency.

## What

Single-line change in [\`MessageView.swift:162\`](https://github.com/exyte/Chat/blob/main/Sources/ExyteChat/Views/MessageView/MessageView.swift#L162):

\`\`\`diff
- .font(.system(size: 12, weight: .bold))
+ .font(.caption.weight(.bold))
\`\`\`

\`.caption\` is the Dynamic-Type-aware text style that's already used a level down (the reply variant uses \`.caption2\`). At default Dynamic Type size both \`.caption\` and \`12pt\` render at the same physical size, so the default-state visual is unchanged; the difference appears only when the user has scaled their accessibility text size.

## Build note

The macOS build path on this repo currently fails dep resolution on \`develop\` (Package.swift declares \`macOS 10.13\` but \`ActivityIndicatorView\` and \`Kingfisher\` require \`10.15\`) — pre-existing, unrelated to this change. iOS builds resolve fine and the source-level diff is a trivial \`.font(\\_:)\` modifier swap that compiles either way.