### PR TITLE
fix: MessageView rendering on sizes smaller than screen size

### DIFF
--- a/Sources/ExyteChat/Views/MessageView/MessageView.swift
+++ b/Sources/ExyteChat/Views/MessageView/MessageView.swift
@@ -21,6 +21,7 @@ struct MessageView: View {
     let isDisplayingMessageMenu: Bool
 
     @State var giphyAspectRatio: CGFloat = 1
+    @State var width = UIScreen.main.bounds.width
 
     static let widthWithMedia: CGFloat = 204
     static let statusViewWidth: CGFloat = 10
@@ -51,7 +52,7 @@ struct MessageView: View {
         let statusViewWithPaddings = MessageView.statusViewWidth + MessageView.horizontalSpacing
         let textPaddings = MessageView.horizontalTextPadding * 2
         let widthWithoutMedia =
-            UIScreen.main.bounds.width
+            width
             - bubblePaddings
             - (isCurrentUser && params.showAvatar ? 0 : avatarViewWithPaddings)
             - (isCurrentUser ? MessageView.statusViewWidth : 0)
@@ -143,6 +144,11 @@ struct MessageView: View {
             maxWidth: UIScreen.main.bounds.width,
             alignment: message.user.isCurrentUser ? .trailing : .leading
         )
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { width in
+            self.width = width
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
# Fix `MessageView` rendering in containers narrower than the screen

## Motivation
<img width="1908" height="969" alt="image" src="https://github.com/user-attachments/assets/56b715ee-900e-4722-b3d5-bee994f18554" />


`MessageView` currently uses `UIScreen.main.bounds.width` to determine the available width for laying out message content and choosing the time view arrangement (`hstack`, `overlay`, or `vstack`).

This works when the chat occupies the full screen, but breaks when `MessageView` is embedded in a container that is narrower than the device screen (for example, side panels, sheets, split views, or custom layouts).

Because the layout logic overestimates the available width, it may incorrectly choose the horizontal (`hstack`) layout, resulting in truncated or clipped message content.

## Changes

* Replace the use of `UIScreen.main.bounds.width` in the layout calculation with the actual rendered width of `MessageView`.
* Introduce a `@State` property to track the current view width.
* Update the width dynamically using `onGeometryChange` and `GeometryReader` so layout decisions are based on the real available space instead of the device screen width.

This preserves the existing behavior for full-screen chats while allowing `MessageView` to render correctly when hosted inside narrower containers.
