### PR TITLE
Fix crash when scrolling to oldest message on an empty table

### DIFF
--- a/Sources/ExyteChat/Views/UIList.swift
+++ b/Sources/ExyteChat/Views/UIList.swift
@@ -158,8 +158,13 @@ struct UIList<MessageContent: View>: UIViewRepresentable {
         case .newestMessage:
             tableView.setContentOffset(CGPoint(x: 0, y: 0), animated: false)
         case .oldestMessage:
-            let lastSection = max(tableView.numberOfSections - 1, 0)
-            let lastRow = max(tableView.numberOfRows(inSection: lastSection) - 1, 0)
+            // An empty table has no section 0 to ask about: clamping the index
+            // to 0 makes numberOfRows(inSection:) raise
+            // "Requested the number of rows for section (0) which is out of bounds".
+            guard tableView.numberOfSections > 0 else { return }
+
+            let lastSection = tableView.numberOfSections - 1
+            let lastRow = tableView.numberOfRows(inSection: lastSection) - 1
 
             guard lastRow >= 0 else { return }
 


### PR DESCRIPTION
Fixes #291.

`performScrollTo`'s `.oldestMessage` branch clamps the section index with `max(numberOfSections - 1, 0)`, so an empty table still asks UIKit for section 0:

```
NSInternalInconsistencyException: Requested the number of rows for section (0) which is out of bounds.
-[UITableViewRowData numberOfRowsInSection:]
```

The existing `guard lastRow >= 0` never fires, because `max(_, 0)` already forced the value non-negative, and it runs after the offending call anyway.

This guards on the section count first, then drops both clamps so the row guard becomes meaningful for an empty section. No behaviour change on a populated table.

The path is reachable in normal use: `onStatusBarTap` arms `pendingScrollTo = .oldestMessage`, and that subscription is a global `NotificationCenter` observer released in `onDisappear`, which does not fire while a `ChatView` stays mounted off screen (a `TabView` tab, or lower in a `NavigationStack`). A status bar tap from another screen then scrolls a chat whose table is still empty. Issue #291 has the full trace and reproduction steps.

Observed on iOS 27.0 with 3.1.7; the same code is on `main` and in 3.2.7.
